### PR TITLE
Fix VectorInput behaviour

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -145,8 +145,7 @@ You can define `props` in your sketch files in order to create GUI elements and 
 | `string` | { disabled?: `boolean`} | `<TextInput>`|
 | `string` | { options?: `string[] \| object[{label?: string, value:string}]`} | `<SelectInput>`|
 | `function` | { disabled?: `boolean`, label?: `string` } | `<ButtonInput>`|
-| `number[](2)` | { locked?: `boolean` } | `<Vec2Input>`|
-| `number[](3)` | { locked?: `boolean` } | `<Vec3Input>`|
+| `number[]` | { locked?: `boolean` } | `<VectorInput>`|
 
 Example:
 ```js

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -92,8 +92,8 @@ $: showOutputParams = (monitor && monitor.selected === "output") ||
                     context={sketchKey}
                     key={key}
                     value={sketchProps[key].value}
-                    params={sketchProps[key].params || {}}
                     type={sketchProps[key].type}
+                    bind:params={sketchProps[key].params}
                     on:click={() => {
                         $props[sketchKey][key].value._refresh = true;
                     }}

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -12,33 +12,34 @@ sketches.subscribe((sketches) => {
 		if (sketch) { // sketch can be undefined if failed to load
 			$props[key] = reconcile(sketch.props, $props[key]);
 		}
-
 	});
 
 	props.set($props);
 });
 
-function reconcile(newProps = {}, existingProps = {}) {
-	Object.keys(newProps).forEach(propKey => {
-		newProps[propKey]._initialValue = newProps[propKey].value;
-	});
-
-	if (existingProps) {
-		Object.keys(existingProps).forEach((propKey) => {
+function reconcile(newProps = {}, prevProps = {}) {
+	if (prevProps) {
+		Object.keys(prevProps).forEach((propKey) => {
+			let prevProp = prevProps[propKey];
 			let newProp = newProps[propKey];
 
-			if (newProp) {
-				let prevProp = existingProps[propKey];
-				let overrideValue = 
-					typeof prevProp._initialValue === "number" && 
-					prevProp._initialValue === newProp._initialValue;
+			console.log(prevProp);
 
-				if (overrideValue) {
-					newProp.value = prevProp.value;
+			if (newProp) {
+				if (!newProp.params) {
+					newProp.params = {};
+				}
+
+				if (prevProp.params) {
+					// reconcile locked VectorInput from UI
+					if (prevProp.params.locked !== undefined) {
+						console.log("reconcile locked param", propKey, prevProp.params.locked);
+						newProp.params.locked = prevProp.params.locked;
+					}
 				}
 			}
 		});
-	};
+	}
 
 	return newProps;
 }

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -23,8 +23,6 @@ function reconcile(newProps = {}, prevProps = {}) {
 			let prevProp = prevProps[propKey];
 			let newProp = newProps[propKey];
 
-			console.log(prevProp);
-
 			if (newProp) {
 				if (!newProp.params) {
 					newProp.params = {};
@@ -33,7 +31,6 @@ function reconcile(newProps = {}, prevProps = {}) {
 				if (prevProp.params) {
 					// reconcile locked VectorInput from UI
 					if (prevProp.params.locked !== undefined) {
-						console.log("reconcile locked param", propKey, prevProp.params.locked);
 						newProp.params.locked = prevProp.params.locked;
 					}
 				}

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -4,30 +4,34 @@ import { sketches } from "./sketches";
 export const props = writable({});
 
 sketches.subscribe((sketches) => {
-	const $props = get(props);
+	props.update((currentProps) => {
+		Object.keys(sketches).forEach((key) => {
+			const sketch = sketches[key];
 
-	Object.keys(sketches).forEach((key) => {
-		const sketch = sketches[key];
+			if (sketch) { // sketch can be undefined if failed to load
+				currentProps[key] = reconcile(sketch.props, currentProps[key]);
+			}
+		});
 
-		if (sketch) { // sketch can be undefined if failed to load
-			$props[key] = reconcile(sketch.props, $props[key]);
-		}
+		return currentProps;
 	});
-
-	props.set($props);
 });
 
 function reconcile(newProps = {}, prevProps = {}) {
+	Object.keys(newProps).forEach((propKey) => {
+		let newProp = newProps[propKey];
+
+		if (!newProp.params) {
+			newProp.params = {};
+		}
+	});
+
 	if (prevProps) {
 		Object.keys(prevProps).forEach((propKey) => {
 			let prevProp = prevProps[propKey];
 			let newProp = newProps[propKey];
 
 			if (newProp) {
-				if (!newProp.params) {
-					newProp.params = {};
-				}
-
 				if (prevProp.params) {
 					// reconcile locked VectorInput from UI
 					if (prevProp.params.locked !== undefined) {

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -4,8 +4,7 @@ import { createEventDispatcher } from "svelte";
 import Select from "./fields/Select.svelte";
 import NumberInput from "./fields/NumberInput.svelte";
 import CheckboxInput from "./fields/CheckboxInput.svelte";
-import Vec2Input from "./fields/Vec2Input.svelte";
-import Vec3Input from "./fields/Vec3Input.svelte";
+import VectorInput from "./fields/VectorInput.svelte";
 import TextInput from "./fields/TextInput.svelte";
 import ColorInput from "./fields/ColorInput.svelte";
 import ListInput from "./fields/ListInput.svelte";
@@ -50,8 +49,7 @@ const dispatch = createEventDispatcher();
 const fields = {
     "select": Select,
     "number": NumberInput,
-    "vec2": Vec2Input,
-    "vec3": Vec3Input,
+    "vec": VectorInput,
     "checkbox": CheckboxInput,
     "text": TextInput,
     "list": ListInput,
@@ -149,7 +147,7 @@ function composeFieldProps(params) {
                     </svg>
                 </button>
             {/if}
-            {#if (fieldType === "vec2" || fieldType === "vec3") && !disabled }
+            {#if (fieldType === "vec") && !disabled }
                 <button class="field__action field__action--lock" on:click={() => params.locked = !params.locked}>
                     {#if params.locked}
                     <svg class="action__icon" width="16" height="16" fill="none" viewBox="0 0 24 24">

--- a/src/client/app/ui/fields/Vec2Input.svelte
+++ b/src/client/app/ui/fields/Vec2Input.svelte
@@ -1,5 +1,0 @@
-<script>
-import VectorInput from "./VectorInput.svelte";
-</script>
-
-<VectorInput {...$$props} on:change/>

--- a/src/client/app/ui/fields/Vec3Input.svelte
+++ b/src/client/app/ui/fields/Vec3Input.svelte
@@ -1,6 +1,0 @@
-<script>
-import VectorInput from "./VectorInput.svelte";
-
-</script>
-
-<VectorInput {...$$props} />

--- a/src/client/app/ui/fields/VectorInput.svelte
+++ b/src/client/app/ui/fields/VectorInput.svelte
@@ -11,72 +11,58 @@ export let step = 0.1;
 export let locked = false;
 export let disabled = false;
 
-function sanitize(value, type) {
-    if (Array.isArray(value)) {
-        return value.reduce((all, v, index) => {
-            if (typeof v === "number") {
-                all[index] = {
-                    value: v,
-                    label: ""
-                }
-            } else {
-                all[index] = v;
-            }
-
-            return all;
-        }, []);
-    } else {
-        return Object.keys(value).map((key) => {
-            return { label: key, value: value[key] }
-        });
-    }
-}
-
-function desanitize(updated) {
-    if (Array.isArray(value)) {
-        return updated.map((v) => v.value);
-    }
-
-    return updated;
-}
-
-$: previousValue = sanitize(value);
-$: currentValue = sanitize(value);
-
 const dispatch = createEventDispatcher();
 
-function onValueChange(index, newValue) {
-    const prevValue = previousValue[index].value;
-    const ratio = newValue / prevValue;
+$: isArray = Array.isArray(value);
+$: isObject = !isArray && typeof value === "object";
+$: components = isObject ? Object.values(value) : value;
+$: keys = isObject ? Object.keys(value) : value.map(() => undefined);
 
-    const updated = currentValue.map((v, i) => {
-        return {
-            ...v,
-            value: i === index ? newValue : 
-                locked ? (Math.round(previousValue[i].value * ratio * (1/step)) / (1/step)) :
-                v.value
-        };
+function dispatchChange() {
+    let needsUpdate = false;
+    for (let i = 0; i < components.length; i++) {
+        const key = isArray ? i : keys[i];
+
+        if (value[key] !== components[i]) {
+            value[key] = components[i];
+            needsUpdate = true;
+        }
+    }
+
+    if (needsUpdate) {
+        dispatch('change', value);
+    }
+}
+
+function handleComponentChange(newValue, componentIndex) {
+    let ratio = newValue / components[componentIndex];
+
+    if (!isFinite(ratio)) {
+        ratio = 1;
+    }
+
+    components = components.map((component, index) => {
+        return index === componentIndex ? newValue : 
+            locked ? (Math.round(component * ratio * (1/step)) / (1/step)) : component;
     });
 
-    currentValue = updated;
-
-    dispatch("change", desanitize(updated));
+    dispatchChange();
 }
 
 </script>
 
-<div class="vector-container vec{currentValue.length}" class:locked={locked}>
-    <FieldInputRow --grid-template-columns={currentValue.map(() => "1fr").join(" ")}>
-        {#each currentValue as curr, index}
+<div class="vector-container vec{components.length}" class:locked={locked}>
+    <FieldInputRow --grid-template-columns={components.map(() => "1fr").join(" ")}>
+        {#each components as component, index}
             <NumberInput
                 {min}
                 {max}
                 {step}
                 {suffix}
                 {disabled}
-                label={curr.label}
-                value={curr.value}
-                on:change={(event) => onValueChange(index, event.detail)}
+                label={keys[index]}
+                value={component}
+                on:change={(event) => handleComponentChange(event.detail, index)}
             />
         {/each}
     </FieldInputRow>

--- a/src/client/app/utils/props.utils.js
+++ b/src/client/app/utils/props.utils.js
@@ -40,14 +40,14 @@ export function inferFromValue(value) {
         }
 
         return "text";
+    } else {
+        const isArray = Array.isArray(value);
+        const isObject = !isArray && typeof value === "object";
+        
+        const values = isObject ? Object.values(value) : value;
 
-    } else if (Array.isArray(value) && value.length === 2) {
-        return "vec2";
-    } else if (Array.isArray(value) && value.length === 3) {
-        return "vec3";
-    } else if (typeof value === "object" && Object.keys(value).length === 3) {
-        return "vec3";
-    } else if (typeof value === "object" && Object.keys(value).length === 2) {
-        return "vec2";
+        if ((isArray || isObject) && values.every(v => typeof v === "number") && values.length <= 4) {
+            return "vec";
+        }
     }
 }


### PR DESCRIPTION
**Summary**

This PR fixes the broken behaviour described in #17. It removes the previous components `<Vec2Input>` and `<Vec3Input>` in favour of the existing `<VectorInput>`, adding support for vec4 without much changes.

**Description**

The inference of `fieldType` based on the value has been changed to `vec` instead of `vec3` and `vec2`. It simplifies the code while also avoiding the kind of mistake like missing bubbling of events described in #17. We also get vec4 support out of the box as VectorInput simply loop over each keys of the given object (or each value of an array made of numbers).
The dispatch of the `change` event has also been improved by making sure `prop.value` reference is updated properly and the dispatch happens only when one of the component has truly changed (therefore not updating if all the components of the given vector are the same).

**Result**
- Support for different vector types: 
```js
export let props = {
  direction: {
    value: { x: 0, y: 0, z: 0}, // vec3 object based
  },
  offset: {
    value: [ 0, 120], // vec2 array like
  },
  position: {
    value: new THREE.Vector3(), // THREE.Vector2, THREE.Vector3, THREE.Vector4 support
  },
};
```
- Direct usage of prop value without relying to `onChange` callback
```js
export let update = () => {
  mesh.position.copy(props.position.value);
}
```
- Preserve value reference
```js
export let props = {
  direction: {
    value: { x: 0, y: 0, z: 0},
    onChange: ({ value }) => {
      console.log(value === props.direction.value); // true
    } 
  }
};
```