### PR TITLE
Fix ColorInput behaviour

### DIFF
--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -200,11 +200,13 @@ function composeFieldProps(params) {
 
 :global(.field__input .field) {
     padding-left: 0px !important;
+    padding-right: 0px !important;
 }
 
 :global(.field__input .field:last-child) {
     border-bottom: 0px solid #323233 !important;
     padding-bottom: 0px !important;
+    
 }
 
 .field.disabled {

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -168,8 +168,6 @@ function onInput(event) {
     bottom: 1px;
 
     border-radius: calc(var(--border-radius-input) * 0.5);
-
-    /* display: none; */
 }
 
 .mirror {
@@ -195,6 +193,7 @@ function onInput(event) {
     background-color: var(--currentColor);
     border-radius: calc(var(--border-radius-input) * 0.5);
     opacity: var(--opacity, 1);
+    pointer-events: none;
 }
 
 .mirror:hover {

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -8,52 +8,47 @@ export let value;
 
 const dispatch = createEventDispatcher();
 
-let hexValue = color.toHex(color.isTHREE(value) ? `#${value.getHexString()}` : value);
-let isInputDriven = true;
-
-let override = false;
-
 let format = color.getColorFormat(value);
-let textValue = formatColorFromHex(hexValue);
+let hexValue = color.toHex(value, format);
+let textValue = color.toString(value, format);
 let alpha = 1;
 
-$: hasAlpha = typeof textValue === "string" &&
-    (
-        color.isRGBAString(textValue) ||
-        color.isVec4String(textValue) ||
-        color.isHSLAString(textValue)
-    );
-$: {
-    if (isInputDriven) {
-        textValue = formatColorFromHex(hexValue);
-    } else {
-        hexValue = color.toHex(textValue);
-    }
-
-    if (color.isTHREE(value)) {
-        const [r, g, b] = color.hexToComponents(hexValue);
-
-        value.r =  r / 255;
-        value.g =  g / 255;
-        value.b =  b / 255;
-    }
-
-    dispatchChange();
-}
-
+$: hasAlpha = [
+    color.FORMATS.RGBA_STRING,
+    color.FORMATS.VEC4_STRING,
+    color.FORMATS.RGBA_OBJECT,
+    color.FORMATS.HSLA_STRING
+].includes(format);
 $: {
     if (hasAlpha) {
-        const [r, g, b, a = 1] = color.toComponents(textValue);
+        const [r, g, b, a = 1] = color.toComponents(value);
         alpha = a;
     }
 }
 
 function dispatchChange() {
+    const [r, g, b] = color.hexToComponents(hexValue);
+
     // support THREE.Color
-    if (format === color.FORMATS.THREE) {
-        dispatch('change', value);
-    } else {
-        dispatch('change', textValue);
+    switch (format) {
+        case color.FORMATS.THREE:
+        case color.FORMATS.RGB_OBJECT:
+            value.r = r;
+            value.g = g;
+            value.b = b;
+
+            dispatch('change', value);
+            break;
+        case color.FORMATS.RGBA_OBJECT:
+            value.r = r;
+            value.g = g;
+            value.b = b;
+            value.a = alpha;
+
+            dispatch('change', value);
+            break;
+        default:
+            dispatch('change', textValue);
     }
 }
 
@@ -61,58 +56,68 @@ function handleBlur() {
     dispatchChange();
 }
 
-function formatColorFromHex(hex) {
-    if (override) return textValue;
-
-    if (format === color.FORMATS.THREE) return color.threeToHexString(value);
-    if (format === color.FORMATS.HEX_STRING) return hex;
-    if (format === color.FORMATS.VEC3_STRING) return color.hexToVec3String(hex);
-    if (format === color.FORMATS.RGB_STRING) return color.hexToRGBString(hex);
-
-    let components = color.hexToComponents(hex);
-
-    if (hasAlpha && alpha !== 1) {
-        components[3] = alpha;
-    }
-
-    if (format === color.FORMATS.HSL_STRING) return color.hexToHSLString(components);
-    if (format === color.FORMATS.RGBA_STRING) return color.componentsToRGBAString(components);
-    if (format === color.FORMATS.VEC4_STRING) return color.componentsToVec4String(components);
-    if (format === color.FORMATS.HSLA_STRING) return color.componentsToHSLAString(components);
-    
-}
-
 function onChangeText(event) {
-    isInputDriven = false;
-
     const newColor = event.detail;
 
     if (color.isColor(newColor)) {
-        format = color.getColorFormat(newColor);
         textValue = newColor;
+    } else {
+        // newColor is not a color, reset value
+        textValue = color.toString(value, format);
     }
+
+    hexValue = color.toHex(textValue);
+    dispatchChange();
 }
 
 function onChangeAlpha(event) {
-    isInputDriven = false;
+    alpha = event.detail;
 
-    if (format === color.FORMATS.RGBA_STRING) {
-        const [r, g, b] = color.hexToComponents(hexValue);
+    const [r, g, b] = color.hexToComponents(hexValue);
 
-        textValue = color.componentsToRGBAString([r, g, b, event.detail]);
-    } else if (format === color.FORMATS.VEC4_STRING) {
-        const [r, g, b] = color.vecToComponents(textValue);
-
-        textValue = color.componentsToVec4String([r, g, b, event.detail]);
-    } else if (format === color.FORMATS.HSLA_STRING) {
-        const [h, s, l] = color.hslToHSLComponents(textValue);
-
-        textValue = color.hslaToHSLAString([h, s, l, event.detail]);
+    switch(format) {
+        case color.FORMATS.RGBA_STRING:
+        case color.FORMATS.RGBA_OBJECT:
+            textValue = color.componentsToRGBAString([r, g, b, alpha]);
+            break;
+        case color.FORMATS.VEC4_STRING:
+            textValue = color.componentsToVec4String([r, g, b, alpha]);
+            break;
+        case color.FORMATS.HSLA_STRING:
+            const [h, s, l] = color.hslToHSLComponents(textValue);
+            textValue = color.hslaToHSLAString([h, s, l, alpha]);
+            break;
     }
+
+    dispatchChange();
 }
 
-function onInput() {
-    isInputDriven = true;
+function onInput(event) {
+    hexValue = event.currentTarget.value;
+
+    const [r, g, b] = color.hexToComponents(hexValue);
+
+    switch(format) {
+        case color.FORMATS.RGBA_STRING:
+        case color.FORMATS.RGBA_OBJECT:
+            textValue = color.toRGBAString({ r, g, b, a: alpha });
+            break;
+        case color.FORMATS.VEC3_STRING:
+            textValue = color.componentsToVec3String([r, g, b]);
+            break;
+        case color.FORMATS.VEC4_STRING:
+            textValue = color.componentsToVec4String([r, g, b, alpha]);
+            break;
+        case color.FORMATS.RGB_STRING:
+        case color.FORMATS.RGB_OBJECT:
+            textValue = color.toRGBString(hexValue);
+            break;
+        default:
+            textValue = color.toString(hexValue);
+            break;
+    }
+
+    dispatchChange();
 }
 
 </script>
@@ -123,7 +128,7 @@ function onInput() {
             <!-- svelte-ignore -->
             <input class="input" type="color" bind:value={hexValue} on:blur={handleBlur} on:input={onInput} />
         </div>
-        <TextInput value={textValue} on:change={onChangeText} />
+        <TextInput bind:value={textValue} on:change={onChangeText} />
     </div>
     {#if hasAlpha }
         <Field key="alpha" value={alpha} params={{min: 0, max: 1, step: 0.01}} on:change={onChangeAlpha}></Field>

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -8,11 +8,10 @@ export let value;
 
 const dispatch = createEventDispatcher();
 
-let format = color.getColorFormat(value);
-let hexValue = color.toHex(value, format);
-let textValue = color.toString(value, format);
-let alpha = 1;
-
+$: format = color.getColorFormat(value);
+$: hexValue = color.toHex(value, format);
+$: textValue = color.toString(value, format);
+$: alpha = 1;
 $: hasAlpha = [
     color.FORMATS.RGBA_STRING,
     color.FORMATS.VEC4_STRING,
@@ -23,6 +22,8 @@ $: {
     if (hasAlpha) {
         const [r, g, b, a = 1] = color.toComponents(value);
         alpha = a;
+    } else {
+        alpha = 1;
     }
 }
 
@@ -116,7 +117,7 @@ function onInput(event) {
             textValue = color.componentsToHSLString([r, g, b]);
             break;
         case color.FORMATS.HSLA_STRING:
-            textValue = color.componentsToHSLString([r, g, b, alpha]);
+            textValue = color.componentsToHSLAString([r, g, b, alpha]);
             break;
         default:
             textValue = color.toString(hexValue);

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -112,6 +112,12 @@ function onInput(event) {
         case color.FORMATS.RGB_OBJECT:
             textValue = color.toRGBString(hexValue);
             break;
+        case color.FORMATS.HSL_STRING:
+            textValue = color.componentsToHSLString([r, g, b]);
+            break;
+        case color.FORMATS.HSLA_STRING:
+            textValue = color.componentsToHSLString([r, g, b, alpha]);
+            break;
         default:
             textValue = color.toString(hexValue);
             break;

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -125,6 +125,18 @@ function onInput(event) {
 <div class="color-input">
     <div class="layout">
         <div class="mirror" style="--currentColor: {hexValue}; --opacity: {alpha}">
+            {#if hasAlpha }
+            <svg width="calc(100% - 2px)" height="calc(100% - 2px)" class="alpha-svg">
+                <pattern id="checker" x="0" y="0" width="7.2" height="7.2" patternUnits="userSpaceOnUse">
+                    <rect fill="white" x="0" width="3.6" height="3.6" y="0"></rect>
+                    <rect fill="grey" x="3.6" width="3.6" height="3.6" y="0"></rect>
+                    <rect fill="white" x="3.6" width="3.6" height="3.6" y="3.6"></rect>
+                    <rect fill="grey" x="0" width="3.6" height="3.6" y="3.6"></rect>
+                </pattern>
+                <!-- The canvas with our applied pattern -->
+                <rect x="0" y="0" width="100%" height="100%" fill="url(#checker)"></rect>
+            </svg>
+            {/if}
             <!-- svelte-ignore -->
             <input class="input" type="color" bind:value={hexValue} on:blur={handleBlur} on:input={onInput} />
         </div>
@@ -148,6 +160,18 @@ function onInput(event) {
     align-items: center;
 }
 
+.alpha-svg {
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    right: 1px;
+    bottom: 1px;
+
+    border-radius: calc(var(--border-radius-input) * 0.5);
+
+    /* display: none; */
+}
+
 .mirror {
     position: relative;
     
@@ -157,11 +181,12 @@ function onInput(event) {
     box-shadow: inset 0 0 0 1px var(--color-border-input);
 }
 
-.mirror:before {
+.mirror:after {
     --gap: 1px;
 
     content: '';
     position: absolute;
+    z-index: 1;
     top: var(--gap);
     left: var(--gap);
     right: var(--gap);

--- a/src/client/app/ui/fields/TextInput.svelte
+++ b/src/client/app/ui/fields/TextInput.svelte
@@ -8,7 +8,7 @@ export let disabled = false;
 </script>
 
 <div class="text-input">
-    <Input {value} {label} {disabled} on:change on:input />
+    <Input bind:value={value} {label} {disabled} on:change on:input />
 </div>
 
 <style>

--- a/src/client/app/utils/color.utils.js
+++ b/src/client/app/utils/color.utils.js
@@ -1,3 +1,65 @@
+export const FORMATS = {
+	HEX_STRING: "hex-string",
+	RGB_STRING: "rgb-string",
+	RGBA_STRING: "rgba-string",
+	HSL_STRING: "hsl-string",
+	HSLA_STRING: "hsla-string",
+	RGB_OBJECT: "rgb-object",
+	RGBA_OBJECT: "rgba-object",
+	VEC3_STRING: "vec3-string",
+	VEC4_STRING: "vec4-string",
+	THREE: "three",
+	CSS_COLOR: "css-color",
+};
+
+export function toHex(color, format = getColorFormat(color)) {
+	if (!format) {
+		console.error(`toHex :: cannot parse color for`, color);
+	}
+
+	if (format === FORMATS.THREE) return threeToHex(color);
+	if (format === FORMATS.HEX_STRING) return color;
+	if (format === FORMATS.HSL_STRING || format === FORMATS.HSLA_STRING) return hslToHex(color);
+	if (format === FORMATS.RGB_STRING || format === FORMATS.RGBA_STRING) return stringToHex(color);
+	if (format === FORMATS.RGB_OBJECT || format === FORMATS.RGBA_OBJECT) return componentsToHex([color.r, color.g, color.b, color.a]);
+	if (format === FORMATS.VEC3_STRING || format === FORMATS.VEC4_STRING) return vecToHex(color);
+	if (format === FORMATS.CSS_COLOR) return nameToHex(color);
+}
+
+export function toComponents(color, format = getColorFormat(color)) {
+	if (!format) {
+		console.error(`toComponents :: cannot parse color for`, color);
+	}
+
+	if (format === FORMATS.THREE) return [color.r, color.g, color.b, 1];
+	if (format === FORMATS.HEX_STRING) return hexToComponents(color);
+	if (format === FORMATS.HSL_STRING || format === FORMATS.HSLA_STRING) return hslToComponents(color);
+	if (format === FORMATS.RGB_STRING || format === FORMATS.RGBA_STRING) return stringToComponents(color);
+	if (format === FORMATS.RGB_OBJECT || format === FORMATS.RGBA_OBJECT) return [color.r, color.g, color.b, isFinite(color.a) ? color.a : 1];
+	if (format === FORMATS.VEC3_STRING || format === FORMATS.VEC4_STRING) return vecToComponents(color);
+	if (format === FORMATS.CSS_COLOR) return nameToComponents(color);
+}
+
+export function toString(color, format = getColorFormat(color)) {
+	if (!format) {
+		console.error(`toString :: cannot parse color for`, color);
+	}
+
+	if (
+		format === FORMATS.HEX_STRING ||
+		format === FORMATS.RGB_STRING ||
+		format === FORMATS.RGBA_STRING ||
+		format === FORMATS.HSL_STRING ||
+		format === FORMATS.HSLA_STRING ||
+		format === FORMATS.VEC3_STRING ||
+		format === FORMATS.VEC4_STRING ||
+		format === FORMATS.CSS_COLOR
+	) return color;
+	if (format === FORMATS.THREE) return threeToHex(color);
+	if (format === FORMATS.RGB_OBJECT) return componentsToRGBString([color.r, color.g, color.b])
+	if (format === FORMATS.RGBA_OBJECT) return componentsToRGBAString([color.r, color.g, color.b, color.a ? color.a : 1]);
+}
+
 /**
  * 
  * @param {string} colorName 
@@ -44,9 +106,9 @@ export function stringToComponents(color) {
 
 	if (match) {
 		return [
-			parseInt(match[1]),
-			parseInt(match[2]),
-			parseInt(match[3]),
+			parseInt(match[1]) / 255,
+			parseInt(match[2]) / 255,
+			parseInt(match[3]) / 255,
 			match[4] ? Number(match[4]) : 1];
 	}
 
@@ -62,9 +124,9 @@ export function vecToComponents(color) {
 
 	if (match) {
 		return [
-			Math.min(255, Math.max(Math.round(Number(match[1]) * 255), 0)),
-			Math.min(255, Math.max(Math.round(Number(match[2]) * 255), 0)),
-			Math.min(255, Math.max(Math.round(Number(match[3]) * 255), 0)),
+			Math.min(1, Math.max(Number(match[1]), 0)),
+			Math.min(1, Math.max(Number(match[2]), 0)),
+			Math.min(1, Math.max(Number(match[3]), 0)),
 			match[4] ? Math.min(1, Math.max(Number(match[4]), 0)) : 1];
 	}
 
@@ -128,7 +190,7 @@ export function hslToComponents(color) {
 	}
 }
 
-export function hlsToHex(color) {
+export function hslToHex(color) {
 	return componentsToHex(hslToComponents(color));
 };
 
@@ -148,9 +210,9 @@ export function hexToComponents(color) {
     }
 
     return [
-		parseInt(color.substr(1, 2), 16),
-        parseInt(color.substr(3, 2), 16),
-		parseInt(color.substr(5, 2), 16),
+		parseInt(color.substr(1, 2), 16) / 255,
+        parseInt(color.substr(3, 2), 16) / 255,
+		parseInt(color.substr(5, 2), 16) / 255,
 		color.length > 7 ? parseInt(color.substr(7, 2), 16)/255 : 1
 	];
 }
@@ -176,16 +238,6 @@ export function hexToHSLAString(color) {
 	return componentsToHSLAString(hexToComponents(color));
 }
 
-export function toComponents(color) {
-	if (isHexString(color)) return hexToComponents(color);
-	if (isRGBAString(color) || isRGBString(color)) return stringToComponents(color);
-	if (isVec3String(color) || isVec4String(color)) return vecToComponents(color);
-	
-	if (typeof color === "string") return nameToComponents(color);
-
-	console.error(`color.toComponents :: cannot parse color`, color);
-}
-
 export function toVec3String(color) {
 	return componentsToVec3String(toComponents(color));
 }
@@ -197,20 +249,20 @@ export function toVec4String(color) {
 export function componentsToVec3String(components = []) {
 	const [ r = 0, g = 0, b = 0] = components;
 
-	let rn = `${Math.round(r / 255 * 100000) / 100000}`;
-	let gn = `${Math.round(g / 255 * 100000) / 100000}`;
-	let bn = `${Math.round(b / 255 * 100000) / 100000}`;
+	let rn = `${Math.round(r * 1000) / 1000}`;
+	let gn = `${Math.round(g * 1000) / 1000}`;
+	let bn = `${Math.round(b * 1000) / 1000}`;
 
-	if (r === 255 || r === 0) {
-		rn = `${rn}.0`;
+	if (r === 1 || r === 0) {
+		rn = `${r}.0`;
 	}
 
-	if (g === 255 || g === 0) {
-		gn = `${gn}.0`;
+	if (g === 1 || g === 0) {
+		gn = `${g}.0`;
 	}
 
-	if (b === 255 || b === 0) {
-		bn = `${bn}.0`;
+	if (b === 1 || b === 0) {
+		bn = `${b}.0`;
 	}
 
 	return `vec3(${rn}, ${gn}, ${bn})`;
@@ -219,21 +271,21 @@ export function componentsToVec3String(components = []) {
 export function componentsToVec4String(components = []) {
 	const [ r = 0, g = 0, b = 0, a = 1] = components;
 
-	let rn = `${Math.round(r / 255 * 100000) / 100000}`;
-	let gn = `${Math.round(g / 255 * 100000) / 100000}`;
-	let bn = `${Math.round(b / 255 * 100000) / 100000}`;
+	let rn = `${Math.round(r * 1000) / 1000}`;
+	let gn = `${Math.round(g * 1000) / 1000}`;
+	let bn = `${Math.round(b * 1000) / 1000}`;
 	let an = `${a}`;
 
-	if (r === 255 || r === 0) {
-		rn = `${rn}.0`;
+	if (r === 1 || r === 0) {
+		rn = `${r}.0`;
 	}
 
-	if (g === 255 || g === 0) {
-		gn = `${gn}.0`;
+	if (g === 1 || g === 0) {
+		gn = `${g}.0`;
 	}
 
-	if (b === 255 || b === 0) {
-		bn = `${bn}.0`;
+	if (b === 1 || b === 0) {
+		bn = `${b}.0`;
 	}
 
 	if (a === 1 || a === 0) {
@@ -243,16 +295,7 @@ export function componentsToVec4String(components = []) {
 	return `vec4(${rn}, ${gn}, ${bn}, ${an})`;
 }
 
-export function toHex(color) {
-	if (isHexString(color)) return color;
-	if (isRGBString(color)) return stringToHex(color);
-	if (isRGBAString(color)) return stringToHex(color);
-	if (isVec3String(color)) return vecToHex(color);
-	if (isVec4String(color)) return vecToHex(color);
-	if (!color.includes('rgb')) return nameToHex(color);
 
-	console.error(`color.toHex :: cannot parse color`, color);
-}
 
 export function toRGBString(color) {
 	const [r, g, b] = toComponents(color);
@@ -275,13 +318,13 @@ export function hexToRGBAString(color) {
 export function componentsToRGBString(components) {
 	const [ r, g, b ] = components;
 
-	return `rgb(${r}, ${g}, ${b})`;
+	return `rgb(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)})`;
 }
 
 export function componentsToRGBAString(components = []) {
 	const [ r = 0, g = 0, b = 0, a = 1 ] = components;
 
-	return `rgba(${r}, ${g}, ${b}, ${a})`;
+	return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
 }
 
 export function componentsToHSLComponents(components = []) {
@@ -328,47 +371,66 @@ export function componentToHex(c) {
 export function componentsToHex(components = []) {
 	const [ r = 0, g = 0, b = 0 ] = components;
 
-	return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+	return "#" + ((1 << 24) + (r * 255 << 16) + (g * 255 << 8) + b * 255).toString(16).slice(1);
 }
 
-export function isHexString(color, isString = typeof color === "string") {
-	return isString && color[0] === "#";
+export function isHexString(value, isString = typeof value === "string") {
+	return isString && value[0] === "#";
 }
 
-export function isRGBAString(color, isString = typeof color === "string") {
-	return isString && color.includes("rgba");
+export function isRGBAString(value, isString = typeof value === "string") {
+	return isString && /rgba\((\d{1,3}),[\s]*(\d{1,3}),[\s]*(\d{1,3})\)?(?:,[\s]*(\d*(?:\.?\d*?))\))?/.test(value);
 }
 
-export function isRGBString(color, isString = typeof color === "string") {
-	return isString && color.includes("rgb");
+export function isRGBString(value, isString = typeof value === "string") {
+	return isString && /rgb\((\d{1,3}),[\s]*(\d{1,3}),[\s]*(\d{1,3})\)/.test(value);
 }
 
-export function isHSLAString(color, isString = typeof color === "string") {
-	return isString && color.includes("hsla");
+export function isHSLAString(value, isString = typeof value === "string") {
+	return isString && value.includes("hsla");
 }
 
-export function isHSLString(color, isString = typeof color === "string") {
-	return isString && color.includes("hsl");
+export function isHSLString(value, isString = typeof value === "string") {
+	return isString && value.includes("hsl");
 }
 
-export function isVec3String(color, isString = typeof color === "string") {
-	return isString && color.includes("vec3(");
+export function isVec3String(value, isString = typeof value === "string") {
+	return isString && value.includes("vec3(");
 }
 
-export function isVec4String(color, isString = typeof color === "string") {
-	return isString && color.includes("vec4(");
+export function isVec4String(value, isString = typeof value === "string") {
+	return isString && value.includes("vec4(");
 }
 
-export function isRGBAArray(value) {
-	return Array.isArray(value) && value.length === 4 && value.every((c, i) => i < 3 ? (c <= 255) : (c <= 1));
+export function isRGBAObject(value) {
+	if (typeof value === "object") {
+		const keys = Object.keys(value);
+
+		return keys.length === 4 &&
+			keys.includes('r') &&
+			keys.includes('g') &&
+			keys.includes('b') &&
+			keys.includes('a');
+	}
+
+	return false;
 }
 
-export function isRGBArray(value) {
-	return Array.isArray(value) && value.length === 3 && value.every(c => c <= 255);
+export function isRGBObject(value) {
+	if (typeof value === "object") {
+		const keys = Object.keys(value);
+
+		return keys.length === 3 &&
+			keys.includes('r') &&
+			keys.includes('g') &&
+			keys.includes('b');
+	}
+
+	return false;
 }
 
-export function isName(value) {
-	const components = nameToComponents(value);
+export function isCSSColor(value, isString = typeof value === "string") {
+	const components = isString && nameToComponents(value);
 
 	return components && components.length > 0;
 }
@@ -377,51 +439,41 @@ export function isTHREE(value) {
 	return value && value.isColor;
 }
 
-export function threeToHexString(value) {
+export function threeToHex(value) {
 	if (!isTHREE(value)) {
-		console.error(`color.threeToHexString() : value is not an instance of THREE.Color`);
+		console.error(`color.threeToHex() : value is not an instance of THREE.Color`);
 	}
 
 	return `#${value.getHexString()}`;
 }
 
-export function isColor(value) {
+export function isColor(value) {
 	let isString = typeof value === "string";
 
+	if (isTHREE(value)) return true;
 	if (isHexString(value, isString)) return true;
 	if (isRGBString(value, isString)) return true;
 	if (isVec3String(value, isString)) return true;
 	if (isVec4String(value, isString)) return true;
 	if (isHSLString(value, isString)) return true;
-	if (isRGBArray(value)) return true;
-	if (isRGBAArray(value)) return true;
-	if (isName(value)) return true;
+	if (isRGBAObject(value)) return true;
+	if (isRGBObject(value)) return true;
+	if (isCSSColor(value)) return true;
 
 	return false;
 }
 
-export const FORMATS = {
-	HEX_STRING: "hex-string",
-	RGB_STRING: "rgb-string",
-	RGBA_STRING: "rgba-string",
-	HSL_STRING: "hsl-string",
-	HSLA_STRING: "hsla-string",
-	RGB_ARRAY: "rgb-array",
-	RGBA_ARRAY: "rgba-array",
-	VEC3_STRING: "vec3-string",
-	VEC4_STRING: "vec4-string",
-	THREE: "three",
-};
 
 export function getColorFormat(value) {
 	if (isTHREE(value)) return FORMATS.THREE;
 	if (isHexString(value)) return FORMATS.HEX_STRING;
 	if (isRGBAString(value)) return FORMATS.RGBA_STRING;
 	if (isRGBString(value)) return FORMATS.RGB_STRING;
-	if (isRGBArray(value)) return FORMATS.RGB_ARRAY;
-	if (isRGBAArray(value)) return FORMATS.RGBA_ARRAY;
+	if (isRGBObject(value)) return FORMATS.RGB_OBJECT;
+	if (isRGBAObject(value)) return FORMATS.RGBA_OBJECT;
 	if (isVec3String(value)) return FORMATS.VEC3_STRING;
 	if (isVec4String(value)) return FORMATS.VEC4_STRING;
 	if (isHSLAString(value)) return FORMATS.HSLA_STRING;
 	if (isHSLString(value)) return FORMATS.HSL_STRING;
+	if (isCSSColor(value)) return FORMATS.CSS_COLOR;
 };

--- a/src/client/app/utils/color.utils.js
+++ b/src/client/app/utils/color.utils.js
@@ -361,7 +361,8 @@ export function componentsToHSLString(components = []) {
 
 export function componentsToHSLAString(components = []) {
 	const [ r = 0, g = 0, b = 0, a = 1 ] = components;
-	return hslaToHSLAString(componentsToHSLComponents([r, g, b]));
+	const [ h, s, l] = componentsToHSLComponents([r, g, b]);
+	return hslaToHSLAString([h, s, l, a]);
 }
 
 export function componentToHex(c) {

--- a/src/client/app/utils/props.utils.js
+++ b/src/client/app/utils/props.utils.js
@@ -24,7 +24,7 @@ export function inferFromParams(params) {
 export function inferFromValue(value) {
     if (value === undefined || value === null) return undefined;
 
-    if (value.isColor) {
+    if (isColor(value)) {
         return "color";
     } else if (typeof value === "number") {
         return "number";
@@ -33,14 +33,11 @@ export function inferFromValue(value) {
     } else if (typeof value === "boolean") {
         return "checkbox";
     } else if (typeof value === "string") {
-        if (isColor(value)) {
-            return "color";
-        } else if (isImage(value)) {
+        if (isImage(value)) {
             return "image";
         }
 
         return "text";
-
     } else if (Array.isArray(value) && value.length === 2) {
         return "vec2";
     } else if (Array.isArray(value) && value.length === 3) {


### PR DESCRIPTION
**Summary**

This PR fixes the broken behaviour of `<ColorInput>`. It improves the inference for color-like values and add support for `hsl` and `hsla` color strings.

**Result**
- Support for different color-like values
```js
export let props = {
  hexString: {
    value: "#0000ff",
  },
  rgbString: {
    value: "rgb(0, 0, 0)", 
  },
  rgbaString: {
    value: "rgba(255, 0, 0, 0.5)",
  },
  rgbObject: {
    value: { r: 0, g: 1, b: 0 },
  },
  rgbaObject: {
    value: { r: 1, g: 0, b: 1, a: 0.25 },
  },
  vec3string: {
    value: "vec3(1.0, 0.0, 0.)",
  },
  vec4string: {
    value: "vec4(0.0, 1.0, 0., 1.)",
  },
  cssColor: {
    value: "purple",
  },
  hslString: {
    value: "hsl(50, 80%, 40%)",
  },
  hslaString: {
    value: "hsla(50, 80%, 10%, 0.1)",
  },
  colorTHREE: {
    value: new THREE.Color(0xFF0000),
  },
};
```
- Fix HSL/HSLA conversion from and to RGB components
- Preserve value reference
```js
export let props = {
  color: {
    value: { r: 0, g: 1, b: 0},
    onChange: ({ value }) => {
      console.log(value === props.color.value); // true
    } 
  }
};
```
- Fix the display of the input when input value has an alpha channel
<img width="763" alt="Capture d’écran, le 2022-09-06 à 18 28 18" src="https://user-images.githubusercontent.com/3669192/188688059-e8c61452-29e8-435d-b006-2603ccc7e008.png">
