### PR TITLE
ProgressInput : prevent unnecessary updates onDrag

### DIFF
--- a/src/client/app/ui/fields/ProgressInput.svelte
+++ b/src/client/app/ui/fields/ProgressInput.svelte
@@ -36,7 +36,9 @@ function onDrag(event) {
     let v = clamp(map(event.clientX, rect.left, rect.right, min, max), min, max);
     v = Math.floor(v * (1 / step)) / (1 / step);
 
-    dispatch("change", v);
+    if (v !== value) {
+        dispatch("change", v);
+    }
 }
 
 function handleMouseUp() {


### PR DESCRIPTION
**Summary**
In `<ProgressInput>`, the `change` event is dispatched on every drag event, causing unnecessary updates when the value doesn't actually change because of `params.step`.

**Description**
For a prop like this one:
```
export let props = {
  offset: {
    value: 2,
    params: {
      min: 1,
      max: 4,
      step: 1,
    }
  }
}
```
`<ProgressInput>` is dispatching `change` events onDrag without checking if the value actually changes, or it can only be `1`, `2`, `3` or `4`. 
For a sketch with `export let fps = 0`, this means `sketch.update()` is called on every drag performed by the user while the `prop.value` actually stays the same.

This PR changes the behaviour by checking the previous value before actually calling `dispatch('change')`.

