### PR TITLE
Improvement/add support for no renderer

### DIFF
--- a/docs/api/CLI.md
+++ b/docs/api/CLI.md
@@ -36,6 +36,7 @@ fragment ./sketch.js --new --template=three/orthographic
 ## Templates
 
 `fragment` currently supports the following templates:
+- [blank](../../src/cli/templates/2d.js)
 - [2d](../../src/cli/templates/2d.js)
 - [fragment](../../src/cli/templates/fragment.js)
 - [three/fragment](../../src/cli/templates/three-fragment.js)

--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -86,7 +86,7 @@ See [SketchProps](#sketchprops) for details.
 #### `rendering`
 - Type: `string`
 - Values: `2d`, `three`, `p5`, `fragment`
-- Default: `2d`
+- Default: undefined
 
 > ⚠ If you used either `three` or `p5` rendering, you'll need to install them from your project root directory in order to make it work.
 

--- a/src/cli/templates/blank.js
+++ b/src/cli/templates/blank.js
@@ -1,0 +1,13 @@
+export let props = {};
+
+export let init = ({ canvas, width, height }) => {
+
+};
+
+export let update = ({ width, height, time, deltaTime }) => {
+	
+};
+
+export let resize = ({ width, height, pixelRatio }) => {
+
+};

--- a/src/cli/templates/index.js
+++ b/src/cli/templates/index.js
@@ -1,4 +1,7 @@
 const templates = {
+	"blank": [
+		"./templates/blank.js"
+	],
 	"2d": [
 		"./templates/2d.js"
 	],

--- a/src/client/app/stores/renderers.js
+++ b/src/client/app/stores/renderers.js
@@ -2,7 +2,7 @@ import { rendering } from "./rendering";
 
 export let renderers = {};
 
-function loadRenderer(renderingMode = "2d") {
+function loadRenderer(renderingMode) {
 	if (__THREE_RENDERER__ && renderingMode === "three") {
 		return import("../renderers/THREERenderer.js");
 	}
@@ -20,7 +20,7 @@ function loadRenderer(renderingMode = "2d") {
 	}
 }
 
-export async function findRenderer(renderingMode = "2d") {
+export async function findRenderer(renderingMode) {
 	if (renderers[renderingMode]) return renderers[renderingMode];
 
 	// load and save
@@ -30,31 +30,33 @@ export async function findRenderer(renderingMode = "2d") {
 	let renderer = renderers[renderingMode];
 	let initialized = false;
 
-	rendering.subscribe((current) => {
-		let r;
+	if (renderer) {
+		rendering.subscribe((current) => {
+			let r;
 
-		if (!initialized) {
-			if (typeof renderer.init === "function") {
-				r = renderer.init({
-					canvas: document.createElement('canvas'),
-					pixelRatio: current.pixelRatio,
+			if (!initialized) {
+				if (typeof renderer.init === "function") {
+					r = renderer.init({
+						canvas: document.createElement('canvas'),
+						pixelRatio: current.pixelRatio,
+						width: current.width,
+						height: current.height,
+					});
+				}
+			}
+
+			initialized = true;
+
+			if (typeof renderer.resize === "function") {
+				renderer.resize({
 					width: current.width,
 					height: current.height,
+					pixelRatio: current.pixelRatio,
+					...r,
 				});
 			}
-		}
-
-		initialized = true;
-
-		if (typeof renderer.resize === "function") {
-			renderer.resize({
-				width: current.width,
-				height: current.height,
-				pixelRatio: current.pixelRatio,
-				...r,
-			});
-		}
-	});
+		});
+	}
 
 	return renderer;
 }

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -190,7 +190,7 @@ async function createSketch(key) {
 
     let mountParams = {};
 
-    if (typeof renderer.onMountPreview === "function") {
+    if (renderer && typeof renderer.onMountPreview === "function") {
         mountParams = renderer.onMountPreview({
             id,
             canvas,
@@ -329,8 +329,8 @@ function createRenderLoop() {
     let playcount = 0;
     let hasDuration = isFinite(duration);
 
-    let onBeforeUpdatePreview = renderer.onBeforeUpdatePreview || noop;
-    let onAfterUpdatePreview = renderer.onAfterUpdatePreview || noop;
+    let onBeforeUpdatePreview = (renderer && renderer.onBeforeUpdatePreview) || noop;
+    let onAfterUpdatePreview = (renderer && renderer.onAfterUpdatePreview) || noop;
 
     let frameLength = 1000 / framerate;
     let frameCount = framerate * duration;


### PR DESCRIPTION
**Description**

Add support for no renderer at all, by removing the fallback to 2D renderer when `rendering` is not provided in the sketch file and allowing renderer to be null across `SketchRenderer.svelte`.
Also added a `blank` template which does nothing by default and provide no additional params to `init()` and `update()`as renderer is `undefined`.