### PR TITLE
bugfix/static build

### DIFF
--- a/src/client/app/stores/sketches.js
+++ b/src/client/app/stores/sketches.js
@@ -3,7 +3,7 @@ import { displayError } from "../stores/errors";
 import { sketches as all, onSketchReload } from "@fragment/sketches";
 
 export const sketches = createStore('sketches', {});
-export const sketchesKeys = createStore('sketchesKeys', []);
+export const sketchesKeys = createStore('sketchesKeys', Object.keys(all));
 export const sketchesCount = createStore('sketchesCount', 0);
 
 async function loadSketch(collection, key) {

--- a/src/client/app/ui/Build.svelte
+++ b/src/client/app/ui/Build.svelte
@@ -22,37 +22,40 @@ let defaultGUIConfig = {
 };
 
 let guiConfig = defaultGUIConfig;
-$: sketchKey = ($layout.previewing && $preview) ? $preview : sketchesKeys[0];
+$: sketchKey = ($layout.previewing && $preview) ? $preview : $sketchesKeys[0];
 $: sketch = $sketches[sketchKey];
 
 $: {
-	if (sketch.buildConfig) {
-		override(sketch.buildConfig);
-	}
-
-	const config = sketch.buildConfig ? sketch.buildConfig : {};
-	gui = config.gui;
-
-	if (gui && typeof gui === "object") {
-		guiConfig = {
-			...defaultGUIConfig,
-			...gui,
-		};
-	}
-
-	const { styles = "" } = config;
-
-	if (styles !== "") {
-		head = document.getElementsByTagName('head')[0];
-
-		if (style) {
-			head.removeChild(style);
+	if (sketch) {
+		if (sketch.buildConfig) {
+			override(sketch.buildConfig);
 		}
 
-		style = document.createElement('style');
-		style.setAttribute('type', 'text/css');
-		style.appendChild(document.createTextNode(styles));
-		head.appendChild(style);
+		const config = sketch.buildConfig ? sketch.buildConfig : {};
+		gui = config.gui;
+
+		if (gui && typeof gui === "object") {
+			guiConfig = {
+				...defaultGUIConfig,
+				...gui,
+			};
+		}
+
+		const { styles = "" } = config;
+
+		if (styles !== "") {
+			head = document.getElementsByTagName('head')[0];
+
+			if (style) {
+				head.removeChild(style);
+			}
+
+			style = document.createElement('style');
+			style.setAttribute('type', 'text/css');
+			style.appendChild(document.createTextNode(styles));
+			head.appendChild(style);
+		}
+
 	}
 }
 


### PR DESCRIPTION
**Summary**

This PR fixes the broken behaviour happening after a sketch build. `sketch` was undefined, throwing an error when trying to access `buildConfig` from the object.

**Description**

- `sketchesKeys` is no longer an array but a svelte store. In order to read its value properly in `Build.svelte`, the variable needs to be prefixed with `$`.
- `sketchesKeys` store is created with a proper initial value instead of an empty array. This allows to read `$sketchesKeys` on component initialization without waiting for an update (which would bring in the same values) on build. 