### PR TITLE
Fix select type handling for options

### DIFF
--- a/src/client/app/ui/fields/Select.svelte
+++ b/src/client/app/ui/fields/Select.svelte
@@ -54,7 +54,6 @@ $: {
         sanitizedOptions[i] = {
             label,
             value: stringifiedValue,
-            _value,
             disabled
         };
     }


### PR DESCRIPTION
**Issue**
The value sent back on change by `Select.svelte` was a string as it was dispatching `event.currentTarget.value` which is always a string. This introduced issues like the following:
```
export let props = {
  hello: {
    value: 4, // props.hello.value is a number
    params: { options: [4, 3, 2, 1] }
    onChange: ({ value }) => {
      console.log(typeof value, props.hello.value); // turned into a string
    }
  }
```
The component was also breaking when options of type `function` or `boolean` were provided.

**Summary**
This PR fixes the broken behaviour of `Select.svelte`.  The value dispatched now is the same type as the provided options.

**Description**
`Select.svelte` now builds a mirrored options array with value as string no matters what has been passed as options. It retrieves the correct value by matching the mirror and the provided options to dispatch the correct value.
- Still support array of primitives as options e.g .`[2, 3, 4]` 
- Still support array of objects with specific keys e.g. `[{ value: variable0, label: "first choice" }, { value: variable1, label: "second choice"}]`
- Added support for all kind of primitives as valid options values: `number`, `boolean`, `function`, `string`, `null` or `undefined`
- Added support for different types as options e.g. `options: ["hello", function (){}, 4]`