### PR TITLE
Prevent local save in build

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -201,7 +201,7 @@ A prop can be `hidden` so it doesn't show up in the Parameters module or in `bui
 export let props = {
   color: {
     value: [255, 0, 255],
-    hidden: __PRODUCTION__,
+    hidden: __BUILD__,
   }
 }
 ```

--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -83,7 +83,9 @@ export async function start({ options, filepaths, entries, fragment }) {
             '__FRAGMENT_PORT__': fragment.server ? fragment.server.port : undefined,
             '__START_TIME__': Date.now(),
             '__SEED__': Date.now(),
-            '__PRODUCTION__': options.build,
+            '__BUILD__': options.build,
+            '__DEV__': !options.build,
+
         },
         optimizeDeps: {
             include: ['convert-length', 'webm-writer', 'changedpi'],

--- a/src/client/app/stores/exports.js
+++ b/src/client/app/stores/exports.js
@@ -20,7 +20,7 @@ export const exports = createStore(`exports`, {
 	imageQuality: 100,
 	videoQuality: 100,
 }, {
-	persist: !__PRODUCTION__,
+	persist: !__BUILD__,
 	reset: false,
 });
 

--- a/src/client/app/stores/layout.js
+++ b/src/client/app/stores/layout.js
@@ -3,7 +3,7 @@ import { getStore, createStore } from "./utils";
 import { onMount } from "svelte";
 
 export const tree = getStore("layout.current", {}, {
-    persist: !__PRODUCTION__
+    persist: !__BUILD__
 });
 
 export const layout = createStore('layout', {

--- a/src/client/app/stores/multisampling.js
+++ b/src/client/app/stores/multisampling.js
@@ -1,16 +1,16 @@
 import { createStore } from "./utils";
 
 export const multisampling = createStore("multisampling", [], {
-	persist: !__PRODUCTION__,
+	persist: !__BUILD__,
 	reset: true,
 });
 
 export const threshold = createStore("threshold", 0, {
-	persist: !__PRODUCTION__,
+	persist: !__BUILD__,
 	reset: false,
 });
 
 export const transition = createStore("transition", false, {
-	persist: !__PRODUCTION__,
+	persist: !__BUILD__,
 	reset: false,
 });

--- a/src/client/app/stores/rendering.js
+++ b/src/client/app/stores/rendering.js
@@ -20,7 +20,7 @@ export const rendering = createStore(`rendering`, {
     scale: 1,
     preset: 'a4',
 }, {
-    persist: !__PRODUCTION__,
+    persist: !__BUILD__,
     reset: false, 
 });
 

--- a/src/client/app/ui/Layout.svelte
+++ b/src/client/app/ui/Layout.svelte
@@ -23,7 +23,7 @@ function togglePreview() {
 </script>
 
 <Root>
-	{#if __PRODUCTION__ || $layout.previewing }
+	{#if __BUILD__ || $layout.previewing }
 		<Build />
 	{:else}
 	<Row size={1}>
@@ -41,7 +41,7 @@ function togglePreview() {
 	</Row>
 	{/if}
 </Root>
-{#if !__PRODUCTION__}
+{#if !__BUILD__}
 	<KeyBinding key="w" on:trigger={toggleEdition} />
 	<KeyBinding key="p" on:trigger={togglePreview} />
 {/if}

--- a/src/client/app/ui/LayoutComponent.svelte
+++ b/src/client/app/ui/LayoutComponent.svelte
@@ -82,7 +82,7 @@ if (parent) {
 	parent.registerChild(current);
 }
 
-if (!__PRODUCTION__) {
+if (!__BUILD__) {
 	$layout.registerChild(current, () => $children);
 }
 

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -136,7 +136,7 @@ function destroyCanvas(canvas) {
 
 function setBackgroundColor() {
     if (sketch) {
-        if (($layout.previewing || __PRODUCTION__) && sketch.buildConfig && sketch.buildConfig.backgroundColor) {
+        if (($layout.previewing || __BUILD__) && sketch.buildConfig && sketch.buildConfig.backgroundColor) {
             backgroundColor = sketch.buildConfig.backgroundColor;
         } else if (!$layout.previewing && sketch.backgroundColor) {
             backgroundColor = sketch.backgroundColor;

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -1,5 +1,5 @@
 export function createBlobFromDataURL(dataURL) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         const splitIndex = dataURL.indexOf(',');
 
         if (splitIndex === -1) {


### PR DESCRIPTION
**Issue**

When hitting `Cmd+S` in build mode, the `screenshotCanvas()` function would try to POST the dataURL to the unexisting dev server in order to save it on disk. 

**Summary**
Allow the POST request only in a dev environment

**Description**
- Added a `__DEV__` global in the vite config
- Encapsulates the POST request only if `__DEV__` is `true`
- Rename __PRODUCTION__ global to `__BUILD__` for better consistency between modes
- Update docs for hiding props between modes
- Added missing `reject` in `createBlobFromDataURL`, causing a type error instead of throwing the error needed for debugging. 