### PR TITLE
Prevent black screenshots in webgl

### DIFF
--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -439,6 +439,8 @@ rendering.subscribe((current) => {
 async function save() {
     paused = true;
 
+    _renderSketch();
+
     await screenshotCanvas(canvas, {
         filename: key,
         pattern: sketch?.filenamePattern,


### PR DESCRIPTION
**Issue**

Depending on OS/browsers, I've been made aware of a bug when trying to screenshot a WebGL canvas (as described here https://webglfundamentals.org/webgl/lessons/webgl-tips.html), which would render a black screenshot instead of the current scene.

**Description**
- Call `_renderSketch` before saving the canvas fixes the issue.
