### PR TITLE
Fix loop count of frame recordings when using fixed duration

### DIFF
--- a/src/client/app/lib/canvas-recorder/CanvasRecorder.js
+++ b/src/client/app/lib/canvas-recorder/CanvasRecorder.js
@@ -49,7 +49,7 @@ class CanvasRecorder {
 	}
 
 	async _tick() {
-		console.log(`CanvasRecorder - render frame ${this.frameCount}`);
+		console.log(`CanvasRecorder - render frame ${this.frameCount + 1}`);
 		this.onTick({
 			time: this.time,
 			deltaTime: this.deltaTime,
@@ -61,14 +61,14 @@ class CanvasRecorder {
 			frameCount: this.frameCount,
 		});
 
-		if (this.started && !this.stopped && (!isFinite(this.frameTotal) || (isFinite(this.frameTotal) && this.frameCount < this.frameTotal))) {
+		if (this.started && !this.stopped && (!isFinite(this.frameTotal) || (isFinite(this.frameTotal) && this.frameCount < this.frameTotal - 1))) {
 			this.time += this.deltaTime;
         	this.frameCount++;
             requestAnimationFrame(() => {
 				this._tick()
 			});
         } else {
-			console.log(`CanvasRecorder - compiling ${this.frameCount} frames...`);
+			console.log(`CanvasRecorder - compiling ${this.frameCount + 1} frames...`);
             this.end();
         }
 	}
@@ -76,7 +76,7 @@ class CanvasRecorder {
 	tick() {}
 
 	end() {
-		console.log(`CanvasRecorder - compiled ${this.frameCount} frames`);
+		console.log(`CanvasRecorder - compiled ${this.frameCount + 1} frames`);
 		this.onComplete(this.result);
 	}
 


### PR DESCRIPTION
**Issue**
When using the duration of a sketch to make a video export, the current `CanvasRecorder` would loop once too often, creating an additional frame at the end that is not supposed to be here.

**Description**
- Compare `frameCount` to `frameTotal - 1` instead of `frameTotal` when exporting a video with a duration
- Improve logs by logging 1-based `frameCount` instead of 0-based value.