### PR TITLE
Add support for color arrays

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -173,7 +173,7 @@ You can force a type on a prop by assigning a `type` to your object like so:
 ```js
 export let props = {
   color: {
-    value: [255, 0, 255],
+    value: [1, 0, 0],
     type: "color",
   }
 }
@@ -188,7 +188,7 @@ function onColorChange({ value }) {
 
 export let props = {
   color: {
-    value: [255, 0, 255],
+    value: [1, 0, 0],
     type: "color",
     onChange: onColorChange,
   }
@@ -200,7 +200,7 @@ A prop can be `hidden` so it doesn't show up in the Parameters module or in `bui
 ```js
 export let props = {
   color: {
-    value: [255, 0, 255],
+    value: [10, 0, 5],
     hidden: __BUILD__,
   }
 }

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -17,6 +17,7 @@ $: alpha = 1;
 $: hasAlpha = [
     color.FORMATS.RGBA_STRING,
     color.FORMATS.VEC4_STRING,
+    color.FORMATS.VEC4_ARRAY,
     color.FORMATS.RGBA_OBJECT,
     color.FORMATS.HSLA_STRING
 ].includes(format);
@@ -34,6 +35,19 @@ function dispatchChange() {
 
     // support THREE.Color
     switch (format) {
+        case color.FORMATS.VEC3_ARRAY:
+            value[0] = r;
+            value[1] = g;
+            value[2] = b;
+            dispatch('change', value);
+            break;
+        case color.FORMATS.VEC4_ARRAY:
+            value[0] = r;
+            value[1] = g;
+            value[2] = b;
+            value[3] = alpha;
+            dispatch('change', value);
+            break;
         case color.FORMATS.THREE:
         case color.FORMATS.RGB_OBJECT:
             value.r = r;


### PR DESCRIPTION
**Summary** 

Allow color conversion from and back to array of length 3 or 4 with values between 0 and 1.

**Description**
This PR adds support for color based on array values like `[1, 0, 0]` (red) or `[0, 1, 0, 0.5]` (green with an alpha of 0.5).
Arrays are still recognized as vectors by default but color recognition can be forced by passing `type: "color"` to the prop object like so:
```js
export let prop = {
  backgroundColor: {
    value: [0, 1, 0]
    type: "color",
  }
}
```
The array reference will be updated when the color input is used.