### PR TITLE
Allow change of directory used for exports

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -11,6 +11,7 @@ sade('fragment [entry]')
     .option('-p, --port', 'Port to bind', 3000)
     .option('-dev, --development', 'Enable development mode', false)
     .option('-b, --build', 'Build sketch for production', false)
+    .option('--exportDir', 'Directory used for exports', process.cwd())
     .option('--outDir', 'Directory used for static build', null)
     .option('--emptyOutDir', "Empty outDir before static build", false)
     .action((entry, options) => {

--- a/docs/api/CLI.md
+++ b/docs/api/CLI.md
@@ -30,6 +30,7 @@ fragment ./sketch.js --new --template=three/orthographic
 |`--template`| `-t` | Specify the type of template to use as source | `2d` |
 |`--port`| `-p` | Specify the server port.  | `3000` |
 |`--build`| `-b` | Build sketch for production  | `false` |
+|`--exportDir`| `none` | Change directory used for export  | `process.cwd()` |
 |`--outDir`| `none` | Change directory used for production build  | `[/[sketch-name]` |
 |`--emptyOutDir`| `none` | Empty outDir before static build  | `false` |
 

--- a/docs/guide/exports.md
+++ b/docs/guide/exports.md
@@ -84,3 +84,8 @@ A built sketch can be previewed on dev mode by typing `p`.
 ## Change the filename
 
 By default, `fragment` will use the sketch filename and a timestamp to name your export like `sketch.js.2022.05.27-08.30.00.[extension]`. See [filenamePattern](../api/sketch.md#filenamepattern) to change this behavior.
+
+## Change the directory of exports
+
+By default, `fragment` will use the directory where the command was started (`process.cwd()`) for saving the exports. This can be changed by passing the `--exportDir=/path/to/custom/directory` to the command line on start.
+ 

--- a/src/cli/plugins/screenshot.js
+++ b/src/cli/plugins/screenshot.js
@@ -1,26 +1,41 @@
 import path from "path";
-import fs from "fs";
+import fs from "fs/promises";
+import fsSync from "fs";
 import bodyParser from "body-parser";
+import log from "../log.js";
 
-export default function screenshot({ cwd }) {
+export default function screenshot({ cwd, exportDir = cwd }) {
+	let dir = (path.isAbsolute(exportDir) ? exportDir : path.join(cwd, exportDir));
+
 	return {
 		name: 'screenshot',
 		configureServer(server){
 			server.middlewares.use(bodyParser.json({ limit: '100mb'}))
-			server.middlewares.use('/save', (req, res, next) => {
+			server.middlewares.use('/save', async (req, res, next) => {
 				if (req.method === "POST") {
 					const { filename, dataURL } = req.body;
 
-					const filepath = path.join(cwd, filename);
+					const filepath = path.join(dir, filename);
 					const buffer = Buffer.from(dataURL, 'base64');
 
-					fs.writeFile(filepath, buffer, (error) => {
-						let statusCode = error ? 500 : 200;
-						let body = error ? { error } : { filepath };
+					if (!fsSync.existsSync(dir)) {
+						try {
+							await fs.mkdir(dir, { recursive: true });
+						} catch(error) {
+							log.error('Cannot create directory for exports');
+							console.log(error);
+						}
+					}
 
-						res.writeHead(statusCode, {'Content-Type': 'application/json'});
-						res.end(JSON.stringify(body));
-					});
+					try {
+						await fs.writeFile(filepath, buffer);
+
+						res.writeHead(200, {'Content-Type': 'application/json'});
+						res.end(JSON.stringify({ filepath }));
+					} catch(error) {
+						res.writeHead(500, {'Content-Type': 'application/json'});
+						res.end(JSON.stringify({ error }));
+					}
 				} else {
 					next();
 				}

--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -62,7 +62,7 @@ export async function start({ options, filepaths, entries, fragment }) {
                 }
             },
             dbPlugin(),
-            screenshotPlugin({ cwd }),
+            screenshotPlugin({ cwd, exportDir: options.exportDir }),
             checkDependencies({
                 cwd,
                 app,


### PR DESCRIPTION
**Summary**

This PR adds a new flag to the CLI `--exportDir` allowing the change of directory used for exports. The `path` given as an argument to `exportDir` will be resolved if it's a relative directory.

**Description**
- Adds flag to the command line with default to `process.cwd()`
- Passes down the option to screenshot plugin
- Resolves the `exportDir` value
- Creates the directory on save if it doesn't exist
- Switches request handler to `async` to allow creation of recursive directory if needed
- Update documentation 