### PR TITLE
Print server urls all the time

### DIFF
--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -1,6 +1,5 @@
 import path from "path";
-import os from 'os';
-import fs from "fs/promises";
+import kleur from "kleur";
 import { fileURLToPath } from 'url';
 import { createServer, defineConfig, build } from "vite";
 import { svelte } from '@sveltejs/vite-plugin-svelte'
@@ -129,8 +128,25 @@ export async function start({ options, filepaths, entries, fragment }) {
         });
 
         await server.listen();
+        
         log.success(`Server started at:`);
-        server.printUrls();
+
+        const { resolvedUrls } = server;
+
+        for (const url of resolvedUrls.local) {
+            console.log(
+                `  ${kleur.green('➜')}  ${kleur.bold('Local')}:   ${kleur.cyan(
+                    url,
+                )}`,
+            );
+        }
+        for (const url of resolvedUrls.network) {
+            console.log(
+                `  ${kleur.green('➜')}  ${kleur.bold('Network')}: ${kleur.cyan(
+                    url,
+                )}`,
+            );
+        }
 
         return server;
     }


### PR DESCRIPTION
#### Issue

Server doesn't print URLs on start anymore

#### Cause
Vite now uses a logger system to allow different log levels. Since `logLevel` is set to `silent` when working with Fragment, this causes the call to `printUrls()` to do nothing.

### Fix
Print URLs by using Vite display from https://github.com/vitejs/vite/blob/8c87af7c03f5b989c8c86cf0c4efb0313c24af82/packages/vite/src/node/logger.ts#L142 and using existing dependency `kleur` for logging.