### PR TITLE
Config exports from sketch

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
 
-import sade from "sade";
-import { run } from "../src/cli/index.js";
+import sade from 'sade';
+import { run } from '../src/cli/index.js';
 
 sade('fragment [entry]')
-    .version('0.1.0')
-    .describe('Run a dev environment for fragment')
-    .option('-n, --new', 'Create file if it does not exist', false)
-    .option('-t, --template', 'Specify template to create the file from', '2d')
-    .option('-p, --port', 'Port to bind', 3000)
-    .option('-dev, --development', 'Enable development mode', false)
-    .option('-b, --build', 'Build sketch for production', false)
-    .option('--exportDir', 'Directory used for exports', process.cwd())
-    .option('--outDir', 'Directory used for static build', null)
-    .option('--emptyOutDir', "Empty outDir before static build", false)
-    .action((entry, options) => {
-        run(entry, options);
-    })
-    .parse(process.argv);
+	.version('0.1.0')
+	.describe('Run a dev environment for fragment')
+	.option('-n, --new', 'Create file if it does not exist', false)
+	.option('-t, --template', 'Specify template to create the file from', '2d')
+	.option('-p, --port', 'Port to bind', 3000)
+	.option('-dev, --development', 'Enable development mode', false)
+	.option('-b, --build', 'Build sketch for production', false)
+	.option('--exportDir', 'Directory used for exports')
+	.option('--outDir', 'Directory used for static build', null)
+	.option('--emptyOutDir', 'Empty outDir before static build', false)
+	.action((entry, options) => {
+		run(entry, options);
+	})
+	.parse(process.argv);

--- a/docs/api/CLI.md
+++ b/docs/api/CLI.md
@@ -30,9 +30,9 @@ fragment ./sketch.js --new --template=three/orthographic
 |`--template`| `-t` | Specify the type of template to use as source | `2d` |
 |`--port`| `-p` | Specify the server port.  | `3000` |
 |`--build`| `-b` | Build sketch for production  | `false` |
-|`--exportDir`| `none` | Change directory used for export  | `process.cwd()` |
-|`--outDir`| `none` | Change directory used for production build  | `[/[sketch-name]` |
-|`--emptyOutDir`| `none` | Empty outDir before static build  | `false` |
+|`--exportDir`| none | Change directory used for export  | `undefined` |
+|`--outDir`| none | Change directory used for production build  | `[/[sketch-name]` |
+|`--emptyOutDir`| none | Empty outDir before static build  | `false` |
 
 ## Templates
 

--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -113,6 +113,23 @@ If you set it to `0`, `fragment` will only call `update()` once at the end of th
 
 Change the value used for display in the monitor dropdown.
 
+#### `exportDir`
+- Type: `string`
+- Default: `process.cwd()`
+
+Change the directory used for exports. The path of the directory can be relative or absolute.
+
+```js
+// relative path
+export let exportDir = './exports';
+```
+```js
+// absolute path
+export let exportDir = '/Users/raphaelameaume/Downloads';
+```
+
+> ⚠️ This will be ignored if fragment is started with the `--exportDir` flag on the command line.
+
 #### `filenamePattern`
 - Type: `({ filename: string, suffix: string, year:string, month:string, day:string, hours:string, minutes:string, seconds:string, props: SketchProps }) => string`
 - Default: `({ filename, suffix }) => ${filename}.${suffix}`

--- a/src/cli/plugins/screenshot.js
+++ b/src/cli/plugins/screenshot.js
@@ -1,27 +1,59 @@
-import path from "path";
-import fs from "fs/promises";
-import fsSync from "fs";
-import bodyParser from "body-parser";
-import log from "../log.js";
+import path from 'path';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import bodyParser from 'body-parser';
+import log from '../log.js';
 
-export default function screenshot({ cwd, exportDir = cwd }) {
-	let dir = (path.isAbsolute(exportDir) ? exportDir : path.join(cwd, exportDir));
+export default function screenshot({ cwd, inlineExportDir }) {
+	function resolveDirectory(directoryPath) {
+		return path.isAbsolute(directoryPath)
+			? directoryPath
+			: path.join(cwd, directoryPath);
+	}
+
+	function resolveExportDirectory({ exportDir }) {
+		let directory;
+
+		if (inlineExportDir) {
+			if (!inlineExportDirPath) {
+				inlineExportDirPath = resolveDirectory(inlineExportDir);
+			}
+
+			directory = inlineExportDirPath;
+
+			if (exportDir) {
+				log.warning(
+					`'exportDir' configuration from sketch has been overridden by --exportDir.`,
+				);
+			}
+		} else if (exportDir) {
+			directory = resolveDirectory(exportDir);
+		} else {
+			directory = cwd;
+		}
+
+		return directory;
+	}
+
+	let inlineExportDirPath;
 
 	return {
 		name: 'screenshot',
-		configureServer(server){
-			server.middlewares.use(bodyParser.json({ limit: '100mb'}))
+		configureServer(server) {
+			server.middlewares.use(bodyParser.json({ limit: '100mb' }));
 			server.middlewares.use('/save', async (req, res, next) => {
-				if (req.method === "POST") {
+				if (req.method === 'POST') {
 					const { filename, dataURL } = req.body;
 
-					const filepath = path.join(dir, filename);
+					let directory = resolveExportDirectory(req.body);
+
+					const filepath = path.join(directory, filename);
 					const buffer = Buffer.from(dataURL, 'base64');
 
-					if (!fsSync.existsSync(dir)) {
+					if (!fsSync.existsSync(directory)) {
 						try {
-							await fs.mkdir(dir, { recursive: true });
-						} catch(error) {
+							await fs.mkdir(directory, { recursive: true });
+						} catch (error) {
 							log.error('Cannot create directory for exports');
 							console.log(error);
 						}
@@ -30,17 +62,22 @@ export default function screenshot({ cwd, exportDir = cwd }) {
 					try {
 						await fs.writeFile(filepath, buffer);
 
-						res.writeHead(200, {'Content-Type': 'application/json'});
+						log.success(`Saved ${filepath}`);
+
+						res.writeHead(200, {
+							'Content-Type': 'application/json',
+						});
 						res.end(JSON.stringify({ filepath }));
-					} catch(error) {
-						res.writeHead(500, {'Content-Type': 'application/json'});
+					} catch (error) {
+						res.writeHead(500, {
+							'Content-Type': 'application/json',
+						});
 						res.end(JSON.stringify({ error }));
 					}
 				} else {
 					next();
 				}
 			});
-		}
-	}
-
+		},
+	};
 }

--- a/src/cli/server.js
+++ b/src/cli/server.js
@@ -1,153 +1,165 @@
-import path from "path";
-import kleur from "kleur";
+import path from 'path';
+import kleur from 'kleur';
 import { fileURLToPath } from 'url';
-import { createServer, defineConfig, build } from "vite";
-import { svelte } from '@sveltejs/vite-plugin-svelte'
-import hotShaderReload from "./plugins/hot-shader-reload.js";
-import hotSketchReload from "./plugins/hot-sketch-reload.js";
-import dbPlugin from "./plugins/db.js";
+import { createServer, defineConfig, build } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import hotShaderReload from './plugins/hot-shader-reload.js';
+import hotSketchReload from './plugins/hot-sketch-reload.js';
+import dbPlugin from './plugins/db.js';
 
-import log from "./log.js";
-import db from "./db.js";
-import screenshotPlugin from "./plugins/screenshot.js";
-import checkDependencies from "./plugins/check-dependencies.js";
+import log from './log.js';
+import db from './db.js';
+import screenshotPlugin from './plugins/screenshot.js';
+import checkDependencies from './plugins/check-dependencies.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export async function start({ options, filepaths, entries, fragment }) {
-    const root = path.join(__dirname, '/../client');
-    const cwd = process.cwd();
-    const app = path.join(root, 'app');
+	const root = path.join(__dirname, '/../client');
+	const cwd = process.cwd();
+	const app = path.join(root, 'app');
 
-    const entriesPaths = entries.map((entry ) => path.join(cwd, entry));
+	const entriesPaths = entries.map((entry) => path.join(cwd, entry));
 
-    const config = defineConfig({
-        configFile: false,
-        root,
-        logLevel: options.development ? "info" : "silent",
-        resolve: {
-            alias: [
-                { find: '@fragment/sketches', replacement: filepaths[0] },
-                { find: '@fragment', replacement: app },
-                { find: 'three', replacement: path.join(cwd, 'node_modules/three') },
-                { find: 'p5', replacement: path.join(cwd, 'node_modules/p5') },
-                { find: 'ogl', replacement: path.join(cwd, 'node_modules/ogl') },
-            ]
-        },
-        plugins: [
-            svelte({
-                configFile: false,
-                onwarn: (warning, handler) => {
-                    if (options.development) {
-                        handler(warning);
-                    } else {
-                        return;
-                    }
-                }
-            }),
-            hotSketchReload({
-                cwd,
-            }),
-            hotShaderReload({ wss: fragment.server }),
-            {
-                name: 'configure-response-headers',
-                configureServer: (server) => {
-                    server.middlewares.use((_req, res, next) => {
-                        res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-                        res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
-                        next();
-                    });
-                }
-            },
-            dbPlugin(),
-            screenshotPlugin({ cwd, exportDir: options.exportDir }),
-            checkDependencies({
-                cwd,
-                app,
-                entriesPaths,
-                build: options.build,
-            })
-        ],
-        server: {
-            port: options.port,
-            host: true,
-            fs: {
-                strict: false,
-                allow: [".."],
-            },
-        },
-        define: {
-            '__CWD__': `${JSON.stringify(cwd)}`,
-            '__FRAGMENT_PORT__': fragment.server ? fragment.server.port : undefined,
-            '__START_TIME__': Date.now(),
-            '__SEED__': Date.now(),
-            '__BUILD__': options.build,
-            '__DEV__': !options.build,
+	const config = defineConfig({
+		configFile: false,
+		root,
+		logLevel: options.development ? 'info' : 'silent',
+		resolve: {
+			alias: [
+				{ find: '@fragment/sketches', replacement: filepaths[0] },
+				{ find: '@fragment', replacement: app },
+				{
+					find: 'three',
+					replacement: path.join(cwd, 'node_modules/three'),
+				},
+				{ find: 'p5', replacement: path.join(cwd, 'node_modules/p5') },
+				{
+					find: 'ogl',
+					replacement: path.join(cwd, 'node_modules/ogl'),
+				},
+			],
+		},
+		plugins: [
+			svelte({
+				configFile: false,
+				onwarn: (warning, handler) => {
+					if (options.development) {
+						handler(warning);
+					} else {
+						return;
+					}
+				},
+			}),
+			hotSketchReload({
+				cwd,
+			}),
+			hotShaderReload({ wss: fragment.server }),
+			{
+				name: 'configure-response-headers',
+				configureServer: (server) => {
+					server.middlewares.use((_req, res, next) => {
+						res.setHeader(
+							'Cross-Origin-Opener-Policy',
+							'same-origin',
+						);
+						res.setHeader(
+							'Cross-Origin-Embedder-Policy',
+							'require-corp',
+						);
+						next();
+					});
+				},
+			},
+			dbPlugin(),
+			screenshotPlugin({ cwd, inlineExportDir: options.exportDir }),
+			checkDependencies({
+				cwd,
+				app,
+				entriesPaths,
+				build: options.build,
+			}),
+		],
+		server: {
+			port: options.port,
+			host: true,
+			fs: {
+				strict: false,
+				allow: ['..'],
+			},
+		},
+		define: {
+			__CWD__: `${JSON.stringify(cwd)}`,
+			__FRAGMENT_PORT__: fragment.server
+				? fragment.server.port
+				: undefined,
+			__START_TIME__: Date.now(),
+			__SEED__: Date.now(),
+			__BUILD__: options.build,
+			__DEV__: !options.build,
+		},
+		optimizeDeps: {
+			include: ['convert-length', 'webm-writer', 'changedpi'],
+			exclude: ['@fragment/sketches', ...entriesPaths],
+		},
+		build: {
+			commonjsOptions: {
+				include: ['convert-length', 'webm-writer', 'changedpi'],
+			},
+		},
+	});
 
-        },
-        optimizeDeps: {
-            include: ['convert-length', 'webm-writer', 'changedpi'],
-            exclude: [
-                "@fragment/sketches",
-                ...entriesPaths,
-            ]
-        },
-        build: {
-            commonjsOptions: {
-                include: ['convert-length', 'webm-writer', 'changedpi'],
-            },
-        },
-    });
+	if (options.build) {
+		if (entries.length > 1) {
+			log.error(`fragment can only build one sketch at a time.`);
+			return;
+		}
 
-    if (options.build) {
-        if (entries.length > 1) {
-            log.error(`fragment can only build one sketch at a time.`);
-            return;
-        }
+		const outDir = options.outDir
+			? options.outDir
+			: entries[0].split('.js')[0];
 
-        const outDir = options.outDir ? options.outDir : entries[0].split('.js')[0];
+		await build({
+			...config,
+			logLevel: 'info',
+			build: {
+				outDir: path.join(process.cwd(), outDir),
+				emptyOutDir: options.emptyOutDir,
+			},
+		});
 
-        await build({
-            ...config,
-            logLevel: "info",
-            build: {
-                outDir: path.join(process.cwd(), outDir),
-                emptyOutDir: options.emptyOutDir,
-            },
-        });
+		log.success(`Built files for:`);
+		entries.forEach((entry) => console.log(`- ${entry}`));
+	} else {
+		log.warning(`Starting server...`);
+		const server = await createServer(config);
 
-        log.success(`Built files for:`);
-        entries.forEach(entry => console.log(`- ${entry}`));
-    } else {
-        log.warning(`Starting server...`);
-        const server = await createServer(config);
+		server.middlewares.use('/db', (req, res, next) => {
+			next();
+		});
 
-        server.middlewares.use('/db', (req, res, next) => {
-            next();
-        });
+		await server.listen();
 
-        await server.listen();
-        
-        log.success(`Server started at:`);
+		log.success(`Server started at:`);
 
-        const { resolvedUrls } = server;
+		const { resolvedUrls } = server;
 
-        for (const url of resolvedUrls.local) {
-            console.log(
-                `  ${kleur.green('➜')}  ${kleur.bold('Local')}:   ${kleur.cyan(
-                    url,
-                )}`,
-            );
-        }
-        for (const url of resolvedUrls.network) {
-            console.log(
-                `  ${kleur.green('➜')}  ${kleur.bold('Network')}: ${kleur.cyan(
-                    url,
-                )}`,
-            );
-        }
+		for (const url of resolvedUrls.local) {
+			console.log(
+				`  ${kleur.green('➜')}  ${kleur.bold('Local')}:   ${kleur.cyan(
+					url,
+				)}`,
+			);
+		}
+		for (const url of resolvedUrls.network) {
+			console.log(
+				`  ${kleur.green('➜')}  ${kleur.bold('Network')}: ${kleur.cyan(
+					url,
+				)}`,
+			);
+		}
 
-        return server;
-    }
+		return server;
+	}
 }

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -1,587 +1,616 @@
 <script>
-import { onMount, onDestroy } from "svelte";
-import { derived } from "svelte/store";
-import KeyBinding from "../components/KeyBinding.svelte";
-import { sketches, sketchesKeys } from "../stores/sketches.js";
-import { layout } from "../stores/layout.js";
-import { rendering, SIZES, sync, monitors } from "../stores/rendering.js";
-import { current as currentTime } from "../stores/time.js";
-import { errors, displayError, clearError } from "../stores/errors.js";
-import { exports, props } from "../stores/index.js";
-import { findRenderer } from "../stores/renderers";
-import { recording, capturing } from "../stores/exports.js";
-import { removeHotListeners } from "../triggers/index.js";
-import { checkForTriggersDown, checkForTriggersMove, checkForTriggersUp, checkForTriggersClick } from "../triggers/Mouse.js";
-import { client } from "../client";
-import { recordCanvas, screenshotCanvas } from "../utils/canvas.utils.js";
-import ErrorOverlay from "./ErrorOverlay.svelte";
-
-export let key;
-export let id = 0;
-export let paused = false;
-export let visible = true;
-
-let node, container;
-let framerate = 60;
-let elapsed = 0;
-let elapsedRenderingTime = 0;
-let now = performance.now(), then = performance.now(), dt = 0, lastTime = performance.now();
-let canvas;
-let _raf;
-let _key = key;
-
-let sketch;
-let _created = false, _errored = false;
-let renderer;
-let noop = () => {};
-let _renderSketch = noop;
-let backgroundColor = "inherit";
-
-function checkForResize() {
-    if (!node) return;
-
-    let needsUpdate = $rendering.resizing === SIZES.WINDOW || $rendering.resizing === SIZES.ASPECT_RATIO;
-
-    let newWidth, newHeight;
-
-    if ($rendering.resizing === SIZES.WINDOW) {
-        newWidth = node.offsetWidth;
-        newHeight = node.offsetHeight;
-    } else if ($rendering.resizing === SIZES.ASPECT_RATIO) {
-        const { offsetWidth, offsetHeight } = node;
-        const aspectRatio = $rendering.aspectRatio;
-        const monitorRatio = offsetWidth / offsetHeight;
-
-        if (aspectRatio < monitorRatio) {
-            newHeight = offsetHeight;
-            newWidth = newHeight * aspectRatio;
-        } else {
-            newWidth = offsetWidth;
-            newHeight = newWidth / aspectRatio;
-        }
-    }
-
-    needsUpdate = needsUpdate && (newWidth !== $rendering.width || newHeight !== $rendering.height);
-
-    if (needsUpdate) {
-        rendering.update(curr => {
-            return {
-                ...curr,
-                width: newWidth,
-                height: newHeight,
-            }
-        });
-    }
-}
-
-let resizeObserver = new ResizeObserver(() => {
-    checkForResize();
-});
-
-let params = {};
-
-let sketchProps = derived(props, () => {
-    return $props[key];
-});
-
-let needsRender = false;
-
-sketchProps.subscribe(() => {
-    if (framerate === 0) {
-        // ensure we don't double render from createSketch
-        requestAnimationFrame(() => {
-            needsRender = true;
-        })
-    }
-});
-
-layout.subscribe(() => {
-    setBackgroundColor();
-});
-
-function createCanvas(canvas = document.createElement('canvas')) {
-    canvas.width = $rendering.width * $rendering.pixelRatio;
-    canvas.height = $rendering.height * $rendering.pixelRatio;
-
-    canvas.onmousedown = (event) => checkForTriggersDown(event, key);
-    canvas.onmousemove = (event) => checkForTriggersMove(event, key);
-    canvas.onmouseup = (event) => checkForTriggersUp(event, key);
-    canvas.onclick = (event) => checkForTriggersClick(event, key);
-
-    container.appendChild(canvas);
-
-    $monitors = $monitors.map((monitor) => {
-        if (monitor.id === id) {
-            return {...monitor, canvas };
-        }
-
-        return monitor;
-    })
-
-    return canvas;
-}
-
-function destroyCanvas(canvas) {
-    canvas.onmousedown = null;
-    canvas.onmousemove = null;
-    canvas.onmouseup = null;
-    canvas.onclick = null;
-    
-    if (canvas.parentNode === container) {
-        canvas.parentNode.removeChild(canvas);
-    }
-
-    canvas = null;
-}
-
-function setBackgroundColor() {
-    if (sketch) {
-        if (($layout.previewing || __BUILD__) && sketch.buildConfig && sketch.buildConfig.backgroundColor) {
-            backgroundColor = sketch.buildConfig.backgroundColor;
-        } else if (!$layout.previewing && sketch.backgroundColor) {
-            backgroundColor = sketch.backgroundColor;
-        } else {
-            backgroundColor = "inherit";    
-        }
-    } else {
-        backgroundColor = "inherit";
-    }
-}
-
-async function createSketch(key) {
-    _created = false;
-
-    sketch = $sketches[key];
-
-    if (!key || !sketch) {
-        _errored = true;
-
-        if (_raf) {
-            cancelAnimationFrame(_raf);
-            _raf = null;
-        }
-
-        return;
-    }
-
-    clearError(key);
-    setBackgroundColor();
-
-    if (canvas) {
-        if (renderer && typeof renderer.onDestroyPreview === "function") {
-            renderer.onDestroyPreview({ id, canvas });
-        }
-
-        destroyCanvas(canvas);
-    }
-
-    renderer = await findRenderer(sketch.rendering);
-
-    if (!container) return;
-
-    canvas = createCanvas();
-
-    if ($rendering.resizing === SIZES.SCALE) {
-        canvas.style.transform = `scale(${$rendering.scale})`;
-    } else {
-        canvas.style.transform = null;
-    }
-
-    removeHotListeners(key);
-
-    let mountParams = {};
-
-    if (renderer && typeof renderer.onMountPreview === "function") {
-        mountParams = renderer.onMountPreview({
-            id,
-            canvas,
-            width: $rendering.width,
-            height: $rendering.height,
-            pixelRatio: $rendering.pixelRatio,
-        });
-    }
-
-    if (mountParams.canvas && mountParams.canvas !== canvas) {
-        destroyCanvas(canvas);
-        canvas = createCanvas(mountParams.canvas);
-    }
-
-    params = {
-        ...mountParams,
-        canvas,
-    };
-
-    framerate = isFinite(sketch.fps) ? sketch.fps : 60;
-
-    const init = sketch.setup || sketch.init || noop;
-    const resize = sketch.resize || noop;
-    const { width, height, pixelRatio } = $rendering;
-
-    try {
-        
-        elapsedRenderingTime = 0;
-
-        if (sketch.load) {
-            await sketch.load();
-        }
-
-        init({
-            width,
-            height,
-            pixelRatio,
-            props,
-            ...params,
-        });
-
-        resize({
-            canvas,
-            width,
-            height,
-            pixelRatio,
-            props,
-            ...params,
-        });
-
-        _created = true;
-        _errored = false;
-
-        _renderSketch = createRenderLoop();
-
-        requestAnimationFrame(() => {
-            needsRender = true;
-
-            if (!_raf) {
-                render();
-            }
-        });
-
-        
-    } catch(error) {
-        onError(error);
-    }
-}
-
-/**
- * 
- * @param {Error} error
- */
-function onError(error) {
-    _errored = true;
-    console.error(error);
-
-    displayError(error, key);    
-
-    cancelAnimationFrame(_raf);
-    _raf = null;
-}
-
-let record = $recording;
-let capture = $capturing;
-
-$: {
-    if ($recording && !record) {
-        let recordOptions = {
-            onTick: _renderSketch,
-            framerate: $exports.framerate,
-            filename: key,
-            pattern: sketch?.filenamePattern,
-            format: $exports.videoFormat,
-            imageEncoding: $exports.imageEncoding,
-            quality: $exports.videoQuality,
-            params: {
-                props: sketch.props,
-            },
-            onStart: () => {
-                elapsedRenderingTime = 0;
-                paused = true;
-            },
-            onComplete: () => {
-                $recording = false;
-                record = null;
-                paused = false;
-            }
-        };
-
-        if ($exports.useDuration) {
-            recordOptions.duration = sketch.duration * $exports.loopCount;
-        }
-
-        record = recordCanvas(canvas, recordOptions);
-    }
-
-    if (record && !$recording) {
-        record.stop();
-        record = false;
-    }
-}
-
-$: {
-    if (!capture && $capturing) {
-        save();
-    }
-}
-
-function createRenderLoop() {
-    const { width, height, pixelRatio } = $rendering;
-    const draw = sketch.draw || sketch.update;
-    const { duration } = sketch;
-
-    let playhead = 0;
-    let playcount = 0;
-    let hasDuration = isFinite(duration);
-
-    let onBeforeUpdatePreview = (renderer && renderer.onBeforeUpdatePreview) || noop;
-    let onAfterUpdatePreview = (renderer && renderer.onAfterUpdatePreview) || noop;
-
-    let frameLength = 1000 / framerate;
-    let frameCount = framerate * duration;
-    let interval = 1 / frameCount;
-
-    return ({ time = performance.now(), deltaTime = time - lastTime } = {}) => {
-        needsRender = false;
-        lastTime = time;
-
-        try {
-            onBeforeUpdatePreview({ id, canvas }); 
-
-            let t = !$sync ? elapsedRenderingTime : Math.floor(time / frameLength) * frameLength;
-
-            if (hasDuration && framerate > 0) {
-                playhead = (t / 1000) / duration;
-                playhead %= 1;
-                playhead = Math.floor(playhead / interval) * interval;
-                playcount = Math.floor(elapsedRenderingTime / 1000 / duration);
-            }
-
-            draw({
-                ...renderer,
-                ...params,
-                props: sketch.props,
-                playhead,
-                playcount,
-                width,
-                height,
-                pixelRatio,
-                time: t,
-                deltaTime,
-            });
-            onAfterUpdatePreview({ id, canvas });
-
-            elapsedRenderingTime += deltaTime;
-        } catch(error) {
-            onError(error);
-        }
-    };
-}
-
-function render() {
-    _raf = requestAnimationFrame(render);
-
-    now = performance.now();
-    dt = now - then;
-    then = now;
-
-    if (!paused) {
-        elapsed += dt;
-
-        if (!$sync) {
-            if ((elapsed) >= ((1 / framerate) * 1000)) {
-                elapsed = 0;
-                _renderSketch();
-            }
-        } else {
-            _renderSketch();
-        }
-    } else {
-        lastTime = now;
-    }
-
-    if (needsRender) {
-        _renderSketch();
-    }
-}
-
-$: {
-    if (canvas && _key !== key) {
-        if (_created) {
-            clearError(_key);
-        }
-
-        _key = key;
-        createSketch(key);
-    }
-}
-
-rendering.subscribe((current) => {
-    if (canvas && _created) {
-        if (current.resizing === SIZES.SCALE) {
-            canvas.style.transform = `scale(${current.scale})`;
-        } else {
-            canvas.style.transform = null;
-        }
-
-        const { width, height, pixelRatio } = current;
-        const resize = sketch.resize || noop;
-        
-        resize({
-            canvas,
-            width,
-            height,
-            pixelRatio,
-            ...params,
-        });
-
-        _renderSketch = createRenderLoop();
-        needsRender = true;
-    }
-});
-
-async function save() {
-    paused = true;
-
-    _renderSketch();
-
-    await screenshotCanvas(canvas, {
-        filename: key,
-        pattern: sketch?.filenamePattern,
-        params: {
-            props: sketch.props,
-        }
-    });
-    paused = false;
-    $capturing = false;
-}
-
-sketches.subscribe(() => {
-    if (_created || _errored) {
-        createSketch(key);
-    }
-});
-
-sync.subscribe(() => {
-    if (_created) {
-        _renderSketch = createRenderLoop();
-    }
-});
-
-onMount(() => {
-    createSketch(key);
-
-    client.on('shader-update', () => {
-        if (framerate === 0) {
-            needsRender = true;
-        }
-    });
-
-    resizeObserver.observe(node);
-})
-
-function checkForPause(event) {
-    const keyboardEvent = event.detail;
-
-    if (!keyboardEvent.metaKey || !keyboardEvent.ctrlKey) {
-        keyboardEvent.preventDefault();
-
-        if (!$recording) {
-            then = performance.now();
-            paused = !paused;
-        } else {
-            console.warn(`Cannot pause while recording.`);
-        }
-    }
-}
-
-function checkForSave(event) {
-    const keyboardEvent = event.detail;
-
-    if (keyboardEvent.metaKey || keyboardEvent.ctrlKey) {
-        keyboardEvent.preventDefault();
-
-        if (!$recording) {
-            save();
-        } else {
-            console.warn(`Cannot save while recording.`);
-        }
-    }
-}
-
-function checkForRecord(event) {
-    const keyboardEvent = event.detail;
-    keyboardEvent.preventDefault();
-
-    $recording = !$recording;
-}
-
-function checkForRefresh(event) {
-    const keyboardEvent = event.detail;
-    if (!keyboardEvent.metaKey && !keyboardEvent.ctrlKey) {
-        keyboardEvent.preventDefault();
-        console.log(`[fragment] ${key} reloaded.`);
-        createSketch(key);
-    }
-}
-
-onDestroy(() => {
-    resizeObserver.unobserve(node);
-    cancelAnimationFrame(_raf);
-
-    if (renderer && typeof renderer.onDestroyPreview === "function") {
-        renderer.onDestroyPreview({ id, canvas });
-    }
-
-    renderer = null;
-
-    if (canvas) {
-        destroyCanvas(canvas);
-    }
-
-    _created = false;
-});
-
-$: {
-    checkForResize();
-
-    if (renderer && typeof renderer.onResizePreview === "function") {
-        renderer.onResizePreview({
-            id,
-            width: $rendering.width,
-            height: $rendering.height,
-            pixelRatio: $rendering.pixelRatio,
-        });
-    }
-
-    if (canvas) {
-        const pixelRatio = $rendering.pixelRatio;
-
-        canvas.width = $rendering.width * pixelRatio;
-        canvas.height = $rendering.height * pixelRatio;
-    }
-}
-
-$: error = (key && $errors.has(key)) ? $errors.get(key) : // display error if error context match current key
-    $errors.size === 1 &&
-    ![...$errors.keys()].some((key) => $sketchesKeys.includes(key)) &&
-    (
-        $monitors.length === 1 || // if there's only one monitor
-        !$monitors.some(m => m.selected === $errors.keys().next().value) // if none of current monitors match the key
-    ) ? $errors.get($errors.keys().next().value) : null;
+	import { onMount, onDestroy } from 'svelte';
+	import { derived } from 'svelte/store';
+	import KeyBinding from '../components/KeyBinding.svelte';
+	import { sketches, sketchesKeys } from '../stores/sketches.js';
+	import { layout } from '../stores/layout.js';
+	import { rendering, SIZES, sync, monitors } from '../stores/rendering.js';
+	import { current as currentTime } from '../stores/time.js';
+	import { errors, displayError, clearError } from '../stores/errors.js';
+	import { exports, props } from '../stores/index.js';
+	import { findRenderer } from '../stores/renderers';
+	import { recording, capturing } from '../stores/exports.js';
+	import { removeHotListeners } from '../triggers/index.js';
+	import {
+		checkForTriggersDown,
+		checkForTriggersMove,
+		checkForTriggersUp,
+		checkForTriggersClick,
+	} from '../triggers/Mouse.js';
+	import { client } from '../client';
+	import { recordCanvas, screenshotCanvas } from '../utils/canvas.utils.js';
+	import ErrorOverlay from './ErrorOverlay.svelte';
+
+	export let key;
+	export let id = 0;
+	export let paused = false;
+	export let visible = true;
+
+	let node, container;
+	let framerate = 60;
+	let elapsed = 0;
+	let elapsedRenderingTime = 0;
+	let now = performance.now(),
+		then = performance.now(),
+		dt = 0,
+		lastTime = performance.now();
+	let canvas;
+	let _raf;
+	let _key = key;
+
+	let sketch;
+	let _created = false,
+		_errored = false;
+	let renderer;
+	let noop = () => {};
+	let _renderSketch = noop;
+	let backgroundColor = 'inherit';
+
+	function checkForResize() {
+		if (!node) return;
+
+		let needsUpdate =
+			$rendering.resizing === SIZES.WINDOW ||
+			$rendering.resizing === SIZES.ASPECT_RATIO;
+
+		let newWidth, newHeight;
+
+		if ($rendering.resizing === SIZES.WINDOW) {
+			newWidth = node.offsetWidth;
+			newHeight = node.offsetHeight;
+		} else if ($rendering.resizing === SIZES.ASPECT_RATIO) {
+			const { offsetWidth, offsetHeight } = node;
+			const aspectRatio = $rendering.aspectRatio;
+			const monitorRatio = offsetWidth / offsetHeight;
+
+			if (aspectRatio < monitorRatio) {
+				newHeight = offsetHeight;
+				newWidth = newHeight * aspectRatio;
+			} else {
+				newWidth = offsetWidth;
+				newHeight = newWidth / aspectRatio;
+			}
+		}
+
+		needsUpdate =
+			needsUpdate &&
+			(newWidth !== $rendering.width || newHeight !== $rendering.height);
+
+		if (needsUpdate) {
+			rendering.update((curr) => {
+				return {
+					...curr,
+					width: newWidth,
+					height: newHeight,
+				};
+			});
+		}
+	}
+
+	let resizeObserver = new ResizeObserver(() => {
+		checkForResize();
+	});
+
+	let params = {};
+
+	let sketchProps = derived(props, () => {
+		return $props[key];
+	});
+
+	let needsRender = false;
+
+	sketchProps.subscribe(() => {
+		if (framerate === 0) {
+			// ensure we don't double render from createSketch
+			requestAnimationFrame(() => {
+				needsRender = true;
+			});
+		}
+	});
+
+	layout.subscribe(() => {
+		setBackgroundColor();
+	});
+
+	function createCanvas(canvas = document.createElement('canvas')) {
+		canvas.width = $rendering.width * $rendering.pixelRatio;
+		canvas.height = $rendering.height * $rendering.pixelRatio;
+
+		canvas.onmousedown = (event) => checkForTriggersDown(event, key);
+		canvas.onmousemove = (event) => checkForTriggersMove(event, key);
+		canvas.onmouseup = (event) => checkForTriggersUp(event, key);
+		canvas.onclick = (event) => checkForTriggersClick(event, key);
+
+		container.appendChild(canvas);
+
+		$monitors = $monitors.map((monitor) => {
+			if (monitor.id === id) {
+				return { ...monitor, canvas };
+			}
+
+			return monitor;
+		});
+
+		return canvas;
+	}
+
+	function destroyCanvas(canvas) {
+		canvas.onmousedown = null;
+		canvas.onmousemove = null;
+		canvas.onmouseup = null;
+		canvas.onclick = null;
+
+		if (canvas.parentNode === container) {
+			canvas.parentNode.removeChild(canvas);
+		}
+
+		canvas = null;
+	}
+
+	function setBackgroundColor() {
+		if (sketch) {
+			if (
+				($layout.previewing || __BUILD__) &&
+				sketch.buildConfig &&
+				sketch.buildConfig.backgroundColor
+			) {
+				backgroundColor = sketch.buildConfig.backgroundColor;
+			} else if (!$layout.previewing && sketch.backgroundColor) {
+				backgroundColor = sketch.backgroundColor;
+			} else {
+				backgroundColor = 'inherit';
+			}
+		} else {
+			backgroundColor = 'inherit';
+		}
+	}
+
+	async function createSketch(key) {
+		_created = false;
+
+		sketch = $sketches[key];
+
+		if (!key || !sketch) {
+			_errored = true;
+
+			if (_raf) {
+				cancelAnimationFrame(_raf);
+				_raf = null;
+			}
+
+			return;
+		}
+
+		clearError(key);
+		setBackgroundColor();
+
+		if (canvas) {
+			if (renderer && typeof renderer.onDestroyPreview === 'function') {
+				renderer.onDestroyPreview({ id, canvas });
+			}
+
+			destroyCanvas(canvas);
+		}
+
+		renderer = await findRenderer(sketch.rendering);
+
+		if (!container) return;
+
+		canvas = createCanvas();
+
+		if ($rendering.resizing === SIZES.SCALE) {
+			canvas.style.transform = `scale(${$rendering.scale})`;
+		} else {
+			canvas.style.transform = null;
+		}
+
+		removeHotListeners(key);
+
+		let mountParams = {};
+
+		if (renderer && typeof renderer.onMountPreview === 'function') {
+			mountParams = renderer.onMountPreview({
+				id,
+				canvas,
+				width: $rendering.width,
+				height: $rendering.height,
+				pixelRatio: $rendering.pixelRatio,
+			});
+		}
+
+		if (mountParams.canvas && mountParams.canvas !== canvas) {
+			destroyCanvas(canvas);
+			canvas = createCanvas(mountParams.canvas);
+		}
+
+		params = {
+			...mountParams,
+			canvas,
+		};
+
+		framerate = isFinite(sketch.fps) ? sketch.fps : 60;
+
+		const init = sketch.setup || sketch.init || noop;
+		const resize = sketch.resize || noop;
+		const { width, height, pixelRatio } = $rendering;
+
+		try {
+			elapsedRenderingTime = 0;
+
+			if (sketch.load) {
+				await sketch.load();
+			}
+
+			init({
+				width,
+				height,
+				pixelRatio,
+				props,
+				...params,
+			});
+
+			resize({
+				canvas,
+				width,
+				height,
+				pixelRatio,
+				props,
+				...params,
+			});
+
+			_created = true;
+			_errored = false;
+
+			_renderSketch = createRenderLoop();
+
+			requestAnimationFrame(() => {
+				needsRender = true;
+
+				if (!_raf) {
+					render();
+				}
+			});
+		} catch (error) {
+			onError(error);
+		}
+	}
+
+	/**
+	 *
+	 * @param {Error} error
+	 */
+	function onError(error) {
+		_errored = true;
+		console.error(error);
+
+		displayError(error, key);
+
+		cancelAnimationFrame(_raf);
+		_raf = null;
+	}
+
+	let record = $recording;
+	let capture = $capturing;
+
+	$: {
+		if ($recording && !record) {
+			let recordOptions = {
+				onTick: _renderSketch,
+				framerate: $exports.framerate,
+				filename: key,
+				exportDir: sketch?.exportDir,
+				pattern: sketch?.filenamePattern,
+				format: $exports.videoFormat,
+				imageEncoding: $exports.imageEncoding,
+				quality: $exports.videoQuality,
+				params: {
+					props: sketch.props,
+				},
+				onStart: () => {
+					elapsedRenderingTime = 0;
+					paused = true;
+				},
+				onComplete: () => {
+					$recording = false;
+					record = null;
+					paused = false;
+				},
+			};
+
+			if ($exports.useDuration) {
+				recordOptions.duration = sketch.duration * $exports.loopCount;
+			}
+
+			record = recordCanvas(canvas, recordOptions);
+		}
+
+		if (record && !$recording) {
+			record.stop();
+			record = false;
+		}
+	}
+
+	$: {
+		if (!capture && $capturing) {
+			save();
+		}
+	}
+
+	function createRenderLoop() {
+		const { width, height, pixelRatio } = $rendering;
+		const draw = sketch.draw || sketch.update;
+		const { duration } = sketch;
+
+		let playhead = 0;
+		let playcount = 0;
+		let hasDuration = isFinite(duration);
+
+		let onBeforeUpdatePreview =
+			(renderer && renderer.onBeforeUpdatePreview) || noop;
+		let onAfterUpdatePreview =
+			(renderer && renderer.onAfterUpdatePreview) || noop;
+
+		let frameLength = 1000 / framerate;
+		let frameCount = framerate * duration;
+		let interval = 1 / frameCount;
+
+		return ({
+			time = performance.now(),
+			deltaTime = time - lastTime,
+		} = {}) => {
+			needsRender = false;
+			lastTime = time;
+
+			try {
+				onBeforeUpdatePreview({ id, canvas });
+
+				let t = !$sync
+					? elapsedRenderingTime
+					: Math.floor(time / frameLength) * frameLength;
+
+				if (hasDuration && framerate > 0) {
+					playhead = t / 1000 / duration;
+					playhead %= 1;
+					playhead = Math.floor(playhead / interval) * interval;
+					playcount = Math.floor(
+						elapsedRenderingTime / 1000 / duration,
+					);
+				}
+
+				draw({
+					...renderer,
+					...params,
+					props: sketch.props,
+					playhead,
+					playcount,
+					width,
+					height,
+					pixelRatio,
+					time: t,
+					deltaTime,
+				});
+				onAfterUpdatePreview({ id, canvas });
+
+				elapsedRenderingTime += deltaTime;
+			} catch (error) {
+				onError(error);
+			}
+		};
+	}
+
+	function render() {
+		_raf = requestAnimationFrame(render);
+
+		now = performance.now();
+		dt = now - then;
+		then = now;
+
+		if (!paused) {
+			elapsed += dt;
+
+			if (!$sync) {
+				if (elapsed >= (1 / framerate) * 1000) {
+					elapsed = 0;
+					_renderSketch();
+				}
+			} else {
+				_renderSketch();
+			}
+		} else {
+			lastTime = now;
+		}
+
+		if (needsRender) {
+			_renderSketch();
+		}
+	}
+
+	$: {
+		if (canvas && _key !== key) {
+			if (_created) {
+				clearError(_key);
+			}
+
+			_key = key;
+			createSketch(key);
+		}
+	}
+
+	rendering.subscribe((current) => {
+		if (canvas && _created) {
+			if (current.resizing === SIZES.SCALE) {
+				canvas.style.transform = `scale(${current.scale})`;
+			} else {
+				canvas.style.transform = null;
+			}
+
+			const { width, height, pixelRatio } = current;
+			const resize = sketch.resize || noop;
+
+			resize({
+				canvas,
+				width,
+				height,
+				pixelRatio,
+				...params,
+			});
+
+			_renderSketch = createRenderLoop();
+			needsRender = true;
+		}
+	});
+
+	async function save() {
+		paused = true;
+
+		_renderSketch();
+
+		await screenshotCanvas(canvas, {
+			filename: key,
+			pattern: sketch?.filenamePattern,
+			exportDir: sketch?.exportDir,
+			params: {
+				props: sketch.props,
+			},
+		});
+		paused = false;
+		$capturing = false;
+	}
+
+	sketches.subscribe(() => {
+		if (_created || _errored) {
+			createSketch(key);
+		}
+	});
+
+	sync.subscribe(() => {
+		if (_created) {
+			_renderSketch = createRenderLoop();
+		}
+	});
+
+	onMount(() => {
+		createSketch(key);
+
+		client.on('shader-update', () => {
+			if (framerate === 0) {
+				needsRender = true;
+			}
+		});
+
+		resizeObserver.observe(node);
+	});
+
+	function checkForPause(event) {
+		const keyboardEvent = event.detail;
+
+		if (!keyboardEvent.metaKey || !keyboardEvent.ctrlKey) {
+			keyboardEvent.preventDefault();
+
+			if (!$recording) {
+				then = performance.now();
+				paused = !paused;
+			} else {
+				console.warn(`Cannot pause while recording.`);
+			}
+		}
+	}
+
+	function checkForSave(event) {
+		const keyboardEvent = event.detail;
+
+		if (keyboardEvent.metaKey || keyboardEvent.ctrlKey) {
+			keyboardEvent.preventDefault();
+
+			if (!$recording) {
+				save();
+			} else {
+				console.warn(`Cannot save while recording.`);
+			}
+		}
+	}
+
+	function checkForRecord(event) {
+		const keyboardEvent = event.detail;
+		keyboardEvent.preventDefault();
+
+		$recording = !$recording;
+	}
+
+	function checkForRefresh(event) {
+		const keyboardEvent = event.detail;
+		if (!keyboardEvent.metaKey && !keyboardEvent.ctrlKey) {
+			keyboardEvent.preventDefault();
+			console.log(`[fragment] ${key} reloaded.`);
+			createSketch(key);
+		}
+	}
+
+	onDestroy(() => {
+		resizeObserver.unobserve(node);
+		cancelAnimationFrame(_raf);
+
+		if (renderer && typeof renderer.onDestroyPreview === 'function') {
+			renderer.onDestroyPreview({ id, canvas });
+		}
+
+		renderer = null;
+
+		if (canvas) {
+			destroyCanvas(canvas);
+		}
+
+		_created = false;
+	});
+
+	$: {
+		checkForResize();
+
+		if (renderer && typeof renderer.onResizePreview === 'function') {
+			renderer.onResizePreview({
+				id,
+				width: $rendering.width,
+				height: $rendering.height,
+				pixelRatio: $rendering.pixelRatio,
+			});
+		}
+
+		if (canvas) {
+			const pixelRatio = $rendering.pixelRatio;
+
+			canvas.width = $rendering.width * pixelRatio;
+			canvas.height = $rendering.height * pixelRatio;
+		}
+	}
+
+	$: error =
+		key && $errors.has(key)
+			? $errors.get(key) // display error if error context match current key
+			: $errors.size === 1 &&
+			  ![...$errors.keys()].some((key) => $sketchesKeys.includes(key)) &&
+			  ($monitors.length === 1 || // if there's only one monitor
+					!$monitors.some(
+						(m) => m.selected === $errors.keys().next().value,
+					)) // if none of current monitors match the key
+			? $errors.get($errors.keys().next().value)
+			: null;
 </script>
 
 <div
-    bind:this={node}
-    class="sketch-renderer"
-    class:visible={visible}
-    class:recording={$recording}
-    style={`--background-color: ${backgroundColor}`}
+	bind:this={node}
+	class="sketch-renderer"
+	class:visible
+	class:recording={$recording}
+	style={`--background-color: ${backgroundColor}`}
 >
-    <div
-        class="canvas-container"
-        style="max-width: {$rendering.width}px; max-height: {$rendering.height}px;"
-        bind:this={container}>
-    </div>
-    {#if $recording}
-        <span class="record">REC</span>
-    {/if}
+	<div
+		class="canvas-container"
+		style="max-width: {$rendering.width}px; max-height: {$rendering.height}px;"
+		bind:this={container}
+	/>
+	{#if $recording}
+		<span class="record">REC</span>
+	{/if}
 </div>
 <KeyBinding type="down" key=" " on:trigger={checkForPause} />
 <KeyBinding type="down" key="r" on:trigger={checkForRefresh} />
@@ -589,95 +618,95 @@ $: error = (key && $errors.has(key)) ? $errors.get(key) : // display error if er
 <KeyBinding type="down" key="S" on:trigger={checkForRecord} />
 
 {#if error}
-    <ErrorOverlay {error} />
+	<ErrorOverlay {error} />
 {/if}
 
 <style>
-.sketch-renderer {
-    position: absolute;
-    display: flex;
-    width: 100%;
-    height: 100%;
-    justify-content: center;
-    align-items: center;
+	.sketch-renderer {
+		position: absolute;
+		display: flex;
+		width: 100%;
+		height: 100%;
+		justify-content: center;
+		align-items: center;
 
-    background-color: var(--background-color, var(--color-lightblack));
-}
+		background-color: var(--background-color, var(--color-lightblack));
+	}
 
-.sketch-renderer:not(.visible) {
-    display: none;
-}
+	.sketch-renderer:not(.visible) {
+		display: none;
+	}
 
-.canvas-container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height: 100%;
-    max-height: 100%;
-}
+	.canvas-container {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		height: 100%;
+		max-height: 100%;
+	}
 
-.sketch-renderer.recording .canvas-container {
-    opacity: 0.5;
-}
+	.sketch-renderer.recording .canvas-container {
+		opacity: 0.5;
+	}
 
-.record {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    z-index: 2;
+	.record {
+		position: absolute;
+		top: 4px;
+		right: 4px;
+		z-index: 2;
 
-    display: flex;
-    place-items: center;
+		display: flex;
+		place-items: center;
 
-    height: 16px;
-    padding: 0 2px;
+		height: 16px;
+		padding: 0 2px;
 
-    color: var(--color-red);
-    font-size: 10px;
+		color: var(--color-red);
+		font-size: 10px;
 
-    border: 1px solid var(--color-red);
-    border-radius: 2px;
-}
+		border: 1px solid var(--color-red);
+		border-radius: 2px;
+	}
 
-.record:before {
-    --size: 6px;
-    content: '';
+	.record:before {
+		--size: 6px;
+		content: '';
 
-    width: var(--size);
-    height: var(--size);
-    margin: 0 3px 0 1px;
+		width: var(--size);
+		height: var(--size);
+		margin: 0 3px 0 1px;
 
-    background-color: var(--color-red);
-    border-radius: 50%;
+		background-color: var(--color-red);
+		border-radius: 50%;
 
-    animation: fade 1s ease-in-out infinite;
-}
+		animation: fade 1s ease-in-out infinite;
+	}
 
-@keyframes fade {
-    0% {
-        opacity: 0;
-    }
+	@keyframes fade {
+		0% {
+			opacity: 0;
+		}
 
-    50% {
-        opacity: 1;
-    }
+		50% {
+			opacity: 1;
+		}
 
-    100% {
-        opacity: 0;
-    }
-}
+		100% {
+			opacity: 0;
+		}
+	}
 
-:global(.canvas-container canvas){
-    max-width: 100%;
-    max-height: 100%;
+	:global(.canvas-container canvas) {
+		max-width: 100%;
+		max-height: 100%;
 
-    flex: none;
+		flex: none;
 
-    width: auto !important;
-    height: auto !important;
+		width: auto !important;
+		height: auto !important;
 
-    background-color: var(--background-color, #000000);
-}
+		background-color: var(--background-color, #000000);
+	}
 </style>

--- a/src/client/app/utils/canvas.utils.js
+++ b/src/client/app/utils/canvas.utils.js
@@ -2,236 +2,249 @@
 https://github.com/mattdesl/canvas-sketch/blob/24f6bb2bbdfdfd72a698a0b8a0962ad843fb7688/lib/save.js
 */
 
-import { changeDpiDataUrl } from "changedpi";
-import { get } from "svelte/store";
-import { exports } from "../stores";
-import { VIDEO_FORMATS } from "../stores/exports";
-import { downloadBlob, createBlobFromDataURL } from "./file.utils";
-import WebMRecorder from "../lib/canvas-recorder/WebMRecorder";
-import MP4Recorder from "../lib/canvas-recorder/MP4Recorder";
-import GIFRecorder from "../lib/canvas-recorder/GIFRecorder";
-import FrameRecorder from "../lib/canvas-recorder/FrameRecorder";
-import { exportCanvas } from "../lib/canvas-recorder/utils";
-import { map } from "./math.utils";
+import { changeDpiDataUrl } from 'changedpi';
+import { get } from 'svelte/store';
+import { exports } from '../stores';
+import { VIDEO_FORMATS } from '../stores/exports';
+import { downloadBlob, createBlobFromDataURL } from './file.utils';
+import WebMRecorder from '../lib/canvas-recorder/WebMRecorder';
+import MP4Recorder from '../lib/canvas-recorder/MP4Recorder';
+import GIFRecorder from '../lib/canvas-recorder/GIFRecorder';
+import FrameRecorder from '../lib/canvas-recorder/FrameRecorder';
+import { exportCanvas } from '../lib/canvas-recorder/utils';
+import { map } from './math.utils';
 
 export async function saveDataURL(dataURL, options, blob) {
-    async function saveInBrowser() {
-        if (!blob) {
-            blob = await createBlobFromDataURL(dataURL);
-        }
+	async function saveInBrowser() {
+		if (!blob) {
+			blob = await createBlobFromDataURL(dataURL);
+		}
 
-        await downloadBlob(blob, options);
-    }
+		await downloadBlob(blob, options);
+	}
 
-    async function onError(err) {
-        if (typeof options.onError === "function") {
-            options.onError(err);
-        }
+	async function onError(err) {
+		if (typeof options.onError === 'function') {
+			options.onError(err);
+		}
 
-        await saveInBrowser();
-    }
+		await saveInBrowser();
+	}
 
-    try {
-        if (__DEV__) {
-            const body = {
-                dataURL: dataURL.split(',')[1], // remove extension,
-                ...options,
-            };
-            const response = await fetch('/save', {
-                method: "POST",
-                body: JSON.stringify(body),
-                headers: {
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json'
-                },
-            });
-            const { filepath, error } = await response.json();
+	try {
+		if (__DEV__) {
+			const body = {
+				dataURL: dataURL.split(',')[1], // remove extension,
+				...options,
+			};
+			const response = await fetch('/save', {
+				method: 'POST',
+				body: JSON.stringify(body),
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+			});
+			const { filepath, error } = await response.json();
 
-            if (response.ok && filepath) {
-                console.log(`[fragment] Saved ${filepath}`);
-            } else {
-                onError(error);
-            }
-        } else {
-            await saveInBrowser();
-        }
-    } catch(error) {
-        onError(error);
-    }
-};
+			if (response.ok && filepath) {
+				console.log(`[fragment] Saved ${filepath}`);
+			} else {
+				onError(error);
+			}
+		} else {
+			await saveInBrowser();
+		}
+	} catch (error) {
+		onError(error);
+	}
+}
 
 export async function createDataURLFromBlob(blob) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        
-        reader.onerror = (err) => {
-            reject(err);
-        };
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
 
-        reader.onload = (e) => {
-            resolve(e.target.result);
-        };
+		reader.onerror = (err) => {
+			reject(err);
+		};
 
-        reader.readAsDataURL(blob);
-    });
+		reader.onload = (e) => {
+			resolve(e.target.result);
+		};
+
+		reader.readAsDataURL(blob);
+	});
 }
 
 export async function saveBlob(blob, options) {
-    const dataURL = await createDataURLFromBlob(blob);
+	const dataURL = await createDataURLFromBlob(blob);
 
-    return saveDataURL(dataURL, options, blob);
-};
-
-function getFilenameParams() {
-    const now = new Date();
-
-    const year = now.toLocaleString('default', { year: 'numeric' });
-    const month = now.toLocaleString('default', { month: 'numeric' }).padStart(2, `0`);
-    const day = now.toLocaleString('default', { day: 'numeric' });
-    const hours = now.toLocaleString('default', { hour: 'numeric' }).split(' ')[0];
-    const minutes = now.toLocaleString('default', { minute: 'numeric' }).padStart(2, `0`);
-    const seconds = now.toLocaleString('default', { second: 'numeric' }).padStart(2, `0`);
-
-    const timestamp = `${year}.${month}.${day}-${hours}.${minutes}.${seconds}`;
-
-    return {
-        year,
-        month,
-        day,
-        hours,
-        minutes,
-        seconds,
-        timestamp,
-    };
+	return saveDataURL(dataURL, options, blob);
 }
 
-export const defaultFilenamePattern = ({
-    filename,
-    timestamp,
-}) => {
-    return `${filename}.${timestamp}`;
+function getFilenameParams() {
+	const now = new Date();
+
+	const year = now.toLocaleString('default', { year: 'numeric' });
+	const month = now
+		.toLocaleString('default', { month: 'numeric' })
+		.padStart(2, `0`);
+	const day = now.toLocaleString('default', { day: 'numeric' });
+	const hours = now
+		.toLocaleString('default', { hour: 'numeric', hour12: false })
+		.split(' ')[0];
+	const minutes = now
+		.toLocaleString('default', { minute: 'numeric' })
+		.padStart(2, `0`);
+	const seconds = now
+		.toLocaleString('default', { second: 'numeric' })
+		.padStart(2, `0`);
+
+	const timestamp = `${year}.${month}.${day}-${hours}.${minutes}.${seconds}`;
+
+	return {
+		year,
+		month,
+		day,
+		hours,
+		minutes,
+		seconds,
+		timestamp,
+	};
+}
+
+export const defaultFilenamePattern = ({ filename, timestamp }) => {
+	return `${filename}.${timestamp}`;
 };
 
-export async function screenshotCanvas(canvas, {
-    filename = "",
-    pattern = defaultFilenamePattern,
-    params = {},
-}) {
-    const { imageEncoding, imageQuality, pixelsPerInch } = get(exports);
-    let { extension, dataURL } = exportCanvas(canvas, {
-        encoding: `image/${imageEncoding}`,
-        encodingQuality: map(imageQuality, 1, 100, 0, 1),
-    });
+export async function screenshotCanvas(
+	canvas,
+	{ filename = '', pattern = defaultFilenamePattern, exportDir, params = {} },
+) {
+	const { imageEncoding, imageQuality, pixelsPerInch } = get(exports);
+	let { extension, dataURL } = exportCanvas(canvas, {
+		encoding: `image/${imageEncoding}`,
+		encodingQuality: map(imageQuality, 1, 100, 0, 1),
+	});
 
-    let patternParams = getFilenameParams();
-    let name = pattern({ filename, ...params, ...patternParams });
+	let patternParams = getFilenameParams();
+	let name = pattern({ filename, ...params, ...patternParams });
 
-    if (imageEncoding !== "webp" && pixelsPerInch !== 72) {
-        dataURL = changeDpiDataUrl(dataURL, pixelsPerInch);
-    }
-    
-    await saveDataURL(dataURL, {
-        filename: `${name}${extension}`,
-        onError: () => {
-            console.error(`[fragment] Error while saving screenshot.`);
-        }
-    });
+	if (imageEncoding !== 'webp' && pixelsPerInch !== 72) {
+		dataURL = changeDpiDataUrl(dataURL, pixelsPerInch);
+	}
+
+	await saveDataURL(dataURL, {
+		filename: `${name}${extension}`,
+		exportDir,
+		onError: (error) => {
+			console.error(`[fragment] Error while saving screenshot.`);
+			console.log(error);
+		},
+	});
 }
 
 function recordCanvasWebM(canvas, options) {
-    let recorder = new WebMRecorder(canvas, options);
-    recorder.start();
+	let recorder = new WebMRecorder(canvas, options);
+	recorder.start();
 
-    return recorder;
+	return recorder;
 }
 
 function recordCanvasMp4(canvas, options) {
-    let recorder = new MP4Recorder(canvas, options);
-    recorder.start();
+	let recorder = new MP4Recorder(canvas, options);
+	recorder.start();
 
-    return recorder;
+	return recorder;
 }
 
 function recordCanvasGIF(canvas, options) {
-    let recorder = new GIFRecorder(canvas, options);
-    recorder.start();
+	let recorder = new GIFRecorder(canvas, options);
+	recorder.start();
 
-    return recorder;
+	return recorder;
 }
 
 function recordCanvasFrames(canvas, options) {
-    let recorder = new FrameRecorder(canvas, options);
-    recorder.start();
+	let recorder = new FrameRecorder(canvas, options);
+	recorder.start();
 
-    return recorder;
+	return recorder;
 }
 
-export function recordCanvas(canvas, {
-    filename = 'output',
-    format = 'mp4',
-    framerate = 25,
-    duration = Infinity,
-    quality = 100,
-    pattern = defaultFilenamePattern,
-    imageEncoding,
-    onStart = () => {},
-    onTick = () => {},
-    onComplete = () => {}
-} = {}) {
-    let patternParams = getFilenameParams();
-    let name = pattern({ filename, ...patternParams });
+export function recordCanvas(
+	canvas,
+	{
+		filename = 'output',
+		format = 'mp4',
+		framerate = 25,
+		duration = Infinity,
+		quality = 100,
+		pattern = defaultFilenamePattern,
+		exportDir,
+		imageEncoding,
+		onStart = () => {},
+		onTick = () => {},
+		onComplete = () => {},
+	} = {},
+) {
+	let patternParams = getFilenameParams();
+	let name = pattern({ filename, ...patternParams });
 
-    function complete(result) {
-        if (Array.isArray(result)) {
-            const frmt = format === VIDEO_FORMATS.FRAMES ? imageEncoding : format;
+	function complete(result) {
+		if (Array.isArray(result)) {
+			const frmt =
+				format === VIDEO_FORMATS.FRAMES ? imageEncoding : format;
 
-            for (let i = 0; i < result.length; i++) {
-                const index = `${i}`.padStart(`${result.length}`.length, '0');
-                saveBlob(result[i], {
-                    filename: `${name}-${index}.${frmt}`,
-                    onError: () => {
-                        console.log(`[fragment] Error while saving record.`);
-                    }
-                });
-            }
-        } else {
-            saveBlob(result, {
-                filename: `${name}.${format}`,
-                onError: () => {
-                    console.log(`[fragment] Error while saving record.`);
-                }
-            });
-        }
-        onComplete();
-    }
+			for (let i = 0; i < result.length; i++) {
+				const index = `${i}`.padStart(`${result.length}`.length, '0');
+				saveBlob(result[i], {
+					filename: `${name}-${index}.${frmt}`,
+					exportDir,
+					onError: () => {
+						console.log(`[fragment] Error while saving record.`);
+					},
+				});
+			}
+		} else {
+			saveBlob(result, {
+				filename: `${name}.${format}`,
+				exportDir,
+				onError: () => {
+					console.log(`[fragment] Error while saving record.`);
+				},
+			});
+		}
+		onComplete();
+	}
 
-    const options = {
-        framerate,
-        duration,
-        quality,
-        onStart,
-        onTick,
-        onComplete: complete,
-    };
+	const options = {
+		framerate,
+		duration,
+		quality,
+		onStart,
+		onTick,
+		onComplete: complete,
+	};
 
-    let recorder;
+	let recorder;
 
-    if (format === VIDEO_FORMATS.WEBM) {
-        recorder = recordCanvasWebM(canvas, options);
-    } else if (format === VIDEO_FORMATS.MP4) {
-        recorder = recordCanvasMp4(canvas, options);
-    } else if (format === VIDEO_FORMATS.GIF) {
-        recorder = recordCanvasGIF(canvas, options);
-    } else if (format === VIDEO_FORMATS.FRAMES) {
-        recorder = recordCanvasFrames(canvas, {
-            ...options,
-            imageEncoding,
-        });
-    }
+	if (format === VIDEO_FORMATS.WEBM) {
+		recorder = recordCanvasWebM(canvas, options);
+	} else if (format === VIDEO_FORMATS.MP4) {
+		recorder = recordCanvasMp4(canvas, options);
+	} else if (format === VIDEO_FORMATS.GIF) {
+		recorder = recordCanvasGIF(canvas, options);
+	} else if (format === VIDEO_FORMATS.FRAMES) {
+		recorder = recordCanvasFrames(canvas, {
+			...options,
+			imageEncoding,
+		});
+	}
 
-    if (!recorder) {
-        console.error(`Cannot find matching recorder`);
-    }
+	if (!recorder) {
+		console.error(`Cannot find matching recorder`);
+	}
 
-    return recorder;
-};
+	return recorder;
+}


### PR DESCRIPTION
#### Summary

This PR adds the ability to change the directory used for exports at the sketch level with a newly available `exportDir`.

It also fixes a small issue with the filestamp used for naming exports. Hours used to generate the timestamp string were 12-hour and not 24-hour, which would cause the files to not be in order when displayed per name in File Explorer/Finder.

```js
export let exportDir = `./exports`;

export let init = () {}
...
```

#### Description
- Pass down `sketch.exportDir` to `screenshotCanvas` and `recordCanvas`
- Prioritize `--exportDir` flag from `sketch.exportDir` when resolving directory for exports
- Update documentation
- Prettier syntax on modified files