### PR TITLE
Custom renderers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 - [Using triggers](./guide/using-triggers.md)
 - [Hot Shader Reloading](./guide/hot-shader-reloading.md)
 - [Shortcuts](./guide/shortcuts.md)
+- [Custom renderers](./guide/custom-renderers.md)
 
 
 ## APIs

--- a/docs/api/renderers.md
+++ b/docs/api/renderers.md
@@ -34,7 +34,7 @@ export let init = ({ renderer, value }) => {
 ```
 
 #### `onMountPreview`
-- Type: `({ index: number, canvas: HTMLCanvasElement }) => MountParams`
+- Type: `({ index: number, canvas: HTMLCanvasElement, container: HTMLElement, width: number, height: number, pixelRatio: number }) => MountParams`
 
 Called everytime a sketch is mounted or hot reloaded. The object returned from this function will spread as params and made available to sketch hooks.
 
@@ -55,22 +55,22 @@ export let update = ({ previewIndex }) => {
 > ⚠️ InitParams and MountParams are both spread at the same level and in this order, so if you export an object key from `init()` and the same key for a different value from `onMountPreview`, `onMountPreview` value will take over as the spread happen {...InitParams, ...MountParams }.
 
 #### `onBeforeUpdatePreview`
-- Type: `({ index: number, canvas: HTMLCanvasElement }) => void`
+- Type: `({ index: number, canvas: HTMLCanvasElement, container: HTMLElement }) => void`
 
 Called on each frame before `sketch.update()`.
 
 #### `onAfterUpdatePreview`
-- Type: `({ index: number, canvas: HTMLCanvasElement }) => void`
+- Type: `({ index: number, canvas: HTMLCanvasElement, container: HTMLElement }) => void`
 
 Called on each frame after `sketch.update()`.
 
 #### `onResizePreview`
-- Type: `({ index: number, canvas: HTMLCanvasElement, width: number, height: number }) => void`
+- Type: `({ index: number, canvas: HTMLCanvasElement, container: HTMLElement, width: number, height: number }) => void`
 
 Called for each preview when OutputParams.canvasSize or OutputParams.dimensions change.
 
 #### `onDestroyPreview`
-- Type: `({ index: number, canvas: HTMLCanvasElement }) => void`
+- Type: `({ index: number, canvas: HTMLCanvasElement, container: HTMLElement }) => void`
 
 Called when a sketch is unmounted or hot reloaded.
 

--- a/docs/guide/custom-renderers.md
+++ b/docs/guide/custom-renderers.md
@@ -1,0 +1,124 @@
+#### <sup>[fragment](../../README.md) → [Documentation](../README.md) → [Guide](../README.md#guide) → Custom renderers</sup>
+<br>
+
+# Custom renderers
+
+`fragment` has built-in support for [Canvas 2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API), [p5.js](https://github.com/processing/p5.js/), [three.js](https://github.com/mrdoob/three.js/) and [WebGL fragment shaders](https://developer.mozilla.org/en-US/docs/Web/API/WebGLShader), however you might want to implement your own renderer.
+
+You can do so by exporting a `renderer` from the sketch file like so:
+
+```js
+import * as SVGRenderer from './custom-svg-renderer.js';
+
+export let renderer = SVGRenderer;
+```
+
+Dynamic imports are also supported by wrapping the import in a `function`.
+
+```js
+export let renderer = () => import('./SVGRenderer');
+```
+
+> ⚠️ Do not mistake `renderer` and `rendering`. The `rendering` export is just a string key used internally by Fragment for retrieving and caching the built-in renderers. The key is not needed when using a custom renderer as it's simply not cached.
+
+## Implementation
+
+Renderers have their own lifecycle inside `fragment`, that can be defined through ESM named-exports just like in a sketch file. 
+You can refer to the [Renderers](../api/renderers.md) API that list available exports and their usage.
+
+## Example
+
+```js
+// custom-svg-renderer
+let previews = [];
+
+export let onMountPreview = ({ id, container, width, height }) => {
+	const element = document.createElementNS(
+		'http://www.w3.org/2000/svg',
+		'svg',
+	);
+	element.setAttribute('id', `svg_${id}`);
+
+	const preview = {
+		id,
+		strings: [],
+		values: [],
+		svg: element,
+	};
+
+	// place element on top of existing canvas
+	element.style.cssText = `
+position: absolute;
+max-width: 100%;
+max-height: 100%;
+flex: none;
+width: auto !important;
+height: auto !important;
+background-color: var(--background-color, #000000);
+`;
+
+	// append svg right after existing canvas, layering it on top of it
+	container.appendChild(element);
+
+	// create a tag function to improve svg readability when writing
+	const svg = (strings, ...values) => {
+		preview.strings = strings;
+		preview.values = values;
+	};
+	previews.push(preview);
+
+	return {
+		svg, // return the tag function, later exposed to sketch hooks
+	};
+};
+
+export let onAfterUpdatePreview = ({
+	id,
+	canvas,
+	width,
+	height,
+	pixelRatio,
+}) => {
+	const preview = previews.find((p) => p.id === id);
+	const { svg, context, strings, values } = preview;
+	const html = String.raw({ raw: strings }, ...values);
+
+	svg.innerHTML = html;
+};
+
+export let onDestroyPreview = ({ id }) => {
+	const previewIndex = previews.findIndex((p) => p.id === id);
+	const preview = previews[previewIndex];
+
+	preview.svg.parentNode.removeChild(preview.svg);
+
+	previews.splice(previewIndex, 1);
+};
+
+export let onResizePreview = ({ id, width, height, pixelRatio }) => {
+	const preview = previews.find((p) => p.id === id);
+	const { svg } = preview;
+
+	const w = width * pixelRatio;
+	const h = height * pixelRatio;
+	svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+	svg.setAttribute('width', w);
+	svg.setAttribute('height', h);
+};
+
+```
+
+```js
+// sketch
+export let renderer = () => import('./custom-svg-renderer.js');
+
+export let update = ({ svg, width, height }) => {
+	// use the tag function exposed by the renderer in `onMountPreview`
+	svg`
+<circle cx="${width * 0.5}" height="${height * 0.5}" r="50" fill="red" />	
+`
+};
+
+```
+
+> ⚠️ In this example, nothing is drawn on the canvas, so the different exports (images or videos) will not work (the files will be blank). You might want to implement your own way of replicating the SVG (in this special case) to the canvas by parsing it and drawing it with a 2D context in `onAfterUpdatePreview`. 

--- a/src/cli/plugins/check-dependencies.js
+++ b/src/cli/plugins/check-dependencies.js
@@ -1,36 +1,45 @@
-import path from "path";
-import fs from "fs";
-import log from "../log.js";
+import path from 'path';
+import fs from 'fs';
+import log from '../log.js';
 
-export default function checkDependencies({ cwd, app, entriesPaths, build } = {}) {
-    const regex = /\bexport[\s]*\b(let|const)[\s]*\brendering\b[\s]*=[\s]*["'](.*?)["']/;
+export default function checkDependencies({
+	cwd,
+	app,
+	entriesPaths,
+	build,
+} = {}) {
+	const regex =
+		/\bexport[\s]*\b(let|const)[\s]*\brendering\b[\s]*=[\s]*["'](.*?)["']/;
 
-    const dependenciesMap = new Map();
-    dependenciesMap.set("three", ["three"]);
-    dependenciesMap.set("p5", ["p5"]);
-    dependenciesMap.set("fragment", []);
-    dependenciesMap.set("2d", []);
+	const dependenciesMap = new Map();
+	dependenciesMap.set('three', ['three']);
+	dependenciesMap.set('p5', ['p5']);
+	dependenciesMap.set('fragment', []);
+	dependenciesMap.set('2d', []);
 
 	const renderers = new Map();
-	renderers.set("three", `${app}/renderers/THREERenderer.js`);
-	renderers.set("p5", `${app}/renderers/P5Renderer.js`);
-	renderers.set("ogl", `${app}/renderers/OGLRenderer.js`);
-	renderers.set("fragment", `${app}/renderers/FragmentRenderer.js`);
-	renderers.set("2d", `${app}/renderers/2DRenderer.js`);
+	renderers.set('three', `${app}/renderers/THREERenderer.js`);
+	renderers.set('p5', `${app}/renderers/P5Renderer.js`);
+	renderers.set('ogl', `${app}/renderers/OGLRenderer.js`);
+	renderers.set('fragment', `${app}/renderers/FragmentRenderer.js`);
+	renderers.set('2d', `${app}/renderers/2DRenderer.js`);
 
 	const renderings = [];
 
 	entriesPaths.forEach((entry) => {
-		const content = fs.readFileSync(entry, { encoding: "utf-8" });
-        const match = content.match(regex);
+		const content = fs.readFileSync(entry, { encoding: 'utf-8' });
+		const match = content.match(regex);
 		const rendering = match && match[2];
 
-		if (rendering) {
+		if (rendering && dependenciesMap.has(rendering)) {
 			renderings.push(rendering);
 
 			const dependencies = dependenciesMap.get(rendering);
 			dependencies.forEach((dependency) => {
-				const dependencyPath = path.join(cwd, `node_modules/${dependency}`);
+				const dependencyPath = path.join(
+					cwd,
+					`node_modules/${dependency}`,
+				);
 				const isInstalled = fs.existsSync(dependencyPath);
 
 				if (!isInstalled) {
@@ -40,7 +49,7 @@ export default function checkDependencies({ cwd, app, entriesPaths, build } = {}
 					console.log(`
 It looks like you're trying to build a ${dependency} sketch (${filename}) without having ${dependency} installed.
 Run 'npm install ${dependency}' before starting Fragment to run ${filename}.
-					`)
+					`);
 
 					throw new Error(error);
 				}
@@ -58,20 +67,28 @@ Run 'npm install ${dependency}' before starting Fragment to run ${filename}.
 		})
 		.flat();
 
-    return {
-        name: 'check-dependencies',
+	return {
+		name: 'check-dependencies',
 		config: () => ({
 			define: {
-				'__THREE_RENDERER__': build ? renderings.some((rendering) => rendering === "three") : true,
-				'__P5_RENDERER__': build ? renderings.some((rendering) => rendering === "p5") : true,
-				'__FRAGMENT_RENDERER__': build ? renderings.some((rendering) => rendering === "fragment") : true,
-				'__2D_RENDERER__': build ? renderings.some((rendering) => rendering === "2d") : true,
+				__THREE_RENDERER__: build
+					? renderings.some((rendering) => rendering === 'three')
+					: true,
+				__P5_RENDERER__: build
+					? renderings.some((rendering) => rendering === 'p5')
+					: true,
+				__FRAGMENT_RENDERER__: build
+					? renderings.some((rendering) => rendering === 'fragment')
+					: true,
+				__2D_RENDERER__: build
+					? renderings.some((rendering) => rendering === '2d')
+					: true,
 			},
 		}),
-        load(id) {
+		load(id) {
 			if (build && skipFiles.includes(id)) {
-				return { code: "", map: null };
+				return { code: '', map: null };
 			}
-        },
-    };
+		},
+	};
 }

--- a/src/client/app/renderers/2DRenderer.js
+++ b/src/client/app/renderers/2DRenderer.js
@@ -1,5 +1,5 @@
 export let onMountPreview = ({ canvas }) => {
-    return {
-        context: canvas.getContext("2d"),
-    }
+	return {
+		context: canvas.getContext('2d'),
+	};
 };

--- a/src/client/app/renderers/P5Renderer.js
+++ b/src/client/app/renderers/P5Renderer.js
@@ -1,4 +1,4 @@
-import p5 from "p5";
+import p5 from 'p5';
 
 let previews = [];
 
@@ -6,7 +6,7 @@ export let onMountPreview = ({ id, width, height }) => {
 	const p = new p5((sketch) => {
 		sketch.setup = () => {
 			sketch.createCanvas(width, height);
-		}
+		};
 	});
 
 	const preview = {
@@ -15,15 +15,15 @@ export let onMountPreview = ({ id, width, height }) => {
 	};
 
 	previews.push(preview);
-	
-    return {
+
+	return {
 		canvas: p.canvas,
 		p,
-    };
+	};
 };
 
 export let onResizePreview = ({ id, width, height, pixelRatio }) => {
-	const preview = previews.find(p => p.id === id);
+	const preview = previews.find((p) => p.id === id);
 
 	if (preview) {
 		preview.p.resizeCanvas(width * pixelRatio, height * pixelRatio, false);
@@ -31,9 +31,12 @@ export let onResizePreview = ({ id, width, height, pixelRatio }) => {
 };
 
 export let onDestroyPreview = ({ id }) => {
-	const preview = previews.find(p => p.id === id);
+	const previewIndex = previews.find((p) => p.id === id);
+	const preview = previews[previewIndex];
 
 	if (preview) {
 		preview.p.remove();
 	}
+
+	previews.splice(previewIndex, 1);
 };

--- a/src/client/app/stores/renderers.js
+++ b/src/client/app/stores/renderers.js
@@ -1,30 +1,37 @@
-import { rendering } from "./rendering";
+import { rendering } from './rendering';
 
 export let renderers = {};
 
 function loadRenderer(renderingMode) {
-	if (__THREE_RENDERER__ && renderingMode === "three") {
-		return import("../renderers/THREERenderer.js");
+	if (renderers[renderingMode]) return renderers[renderingMode];
+
+	if (__THREE_RENDERER__ && renderingMode === 'three') {
+		return import('../renderers/THREERenderer.js');
 	}
 
-	if (__FRAGMENT_RENDERER__ && renderingMode === "fragment") {
-		return import("../renderers/FragmentRenderer.js");
+	if (__FRAGMENT_RENDERER__ && renderingMode === 'fragment') {
+		return import('../renderers/FragmentRenderer.js');
 	}
 
-	if (__P5_RENDERER__ && renderingMode === "p5") {
-		return import("../renderers/P5Renderer.js");
+	if (__P5_RENDERER__ && renderingMode === 'p5') {
+		return import('../renderers/P5Renderer.js');
 	}
 
-	if (__2D_RENDERER__ && renderingMode === "2d") {
-		return import("../renderers/2DRenderer.js");
+	if (__2D_RENDERER__ && renderingMode === '2d') {
+		return import('../renderers/2DRenderer.js');
 	}
 }
 
-export async function findRenderer(renderingMode) {
-	if (renderers[renderingMode]) return renderers[renderingMode];
-
+export async function findRenderer({
+	rendering: renderingMode,
+	renderer: customRenderer,
+}) {
 	// load and save
-	renderers[renderingMode] = await loadRenderer(renderingMode);
+	renderers[renderingMode] = customRenderer
+		? typeof customRenderer === 'function'
+			? await customRenderer()
+			: customRenderer
+		: await loadRenderer(renderingMode);
 
 	// get
 	let renderer = renderers[renderingMode];
@@ -35,7 +42,7 @@ export async function findRenderer(renderingMode) {
 			let r;
 
 			if (!initialized) {
-				if (typeof renderer.init === "function") {
+				if (typeof renderer.init === 'function') {
 					r = renderer.init({
 						canvas: document.createElement('canvas'),
 						pixelRatio: current.pixelRatio,
@@ -47,7 +54,7 @@ export async function findRenderer(renderingMode) {
 
 			initialized = true;
 
-			if (typeof renderer.resize === "function") {
+			if (typeof renderer.resize === 'function') {
 				renderer.resize({
 					width: current.width,
 					height: current.height,

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -192,7 +192,10 @@
 			destroyCanvas(canvas);
 		}
 
-		renderer = await findRenderer(sketch.rendering);
+		renderer = await findRenderer({
+			rendering: sketch.rendering,
+			renderer: sketch.renderer,
+		});
 
 		if (!container) return;
 
@@ -212,6 +215,7 @@
 			mountParams = renderer.onMountPreview({
 				id,
 				canvas,
+				container,
 				width: $rendering.width,
 				height: $rendering.height,
 				pixelRatio: $rendering.pixelRatio,
@@ -362,7 +366,7 @@
 			lastTime = time;
 
 			try {
-				onBeforeUpdatePreview({ id, canvas });
+				onBeforeUpdatePreview({ id, canvas, container });
 
 				let t = !$sync
 					? elapsedRenderingTime
@@ -389,7 +393,7 @@
 					time: t,
 					deltaTime,
 				});
-				onAfterUpdatePreview({ id, canvas });
+				onAfterUpdatePreview({ id, canvas, container });
 
 				elapsedRenderingTime += deltaTime;
 			} catch (error) {
@@ -420,7 +424,7 @@
 			lastTime = now;
 		}
 
-		if (needsRender) {
+		if (needsRender && _created) {
 			_renderSketch();
 		}
 	}
@@ -551,7 +555,7 @@
 		cancelAnimationFrame(_raf);
 
 		if (renderer && typeof renderer.onDestroyPreview === 'function') {
-			renderer.onDestroyPreview({ id, canvas });
+			renderer.onDestroyPreview({ id, canvas, container });
 		}
 
 		renderer = null;
@@ -569,6 +573,7 @@
 		if (renderer && typeof renderer.onResizePreview === 'function') {
 			renderer.onResizePreview({
 				id,
+				container,
 				width: $rendering.width,
 				height: $rendering.height,
 				pixelRatio: $rendering.pixelRatio,


### PR DESCRIPTION
**Summary**

This PR adds the ability to define a custom renderer from a sketch file by allowing a new named export `renderer`. 

**Details**

- Support for new `renderer`
- Allow for static and dynamic imports of renderers
- Expose `container` (HTML node containing the `<canvas>`) to renderer's hooks.
- Prevent error when checking for dependencies when using a custom renderer
- Update guide with a new `Custom renderers` section featuring an example
- Prettier formatting on changed files