### PR TITLE
Fix disabling props

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -156,12 +156,12 @@ You can define `props` in your sketch files in order to create GUI elements and 
 
 | value type | params | field |
 |---|---|---|
-| `number` | { disabled?: `boolean`, step?: `number` } | `<NumberInput>` |
-| `number` | { min:`number`, max: `number` } | `<ProgressInput>` + `<NumberInput>` |
+| `number` | { step?: `number` } | `<NumberInput>` |
+| `number` | { min:`number`, max: `number`, step?: `number` } | `<ProgressInput>` + `<NumberInput>` |
 | `number` | { options?: `number[] \| object[{label?: string, value:number}]`} | `<SelectInput>`|
-| `string` | { disabled?: `boolean`} | `<TextInput>`|
+| `string` | { label?: `string`} | `<TextInput>`|
 | `string` | { options?: `string[] \| object[{label?: string, value:string}]`} | `<SelectInput>`|
-| `function` | { disabled?: `boolean`, label?: `string` } | `<ButtonInput>`|
+| `function` | { label?: `string` } | `<ButtonInput>`|
 | `number[]` | { locked?: `boolean` } | `<VectorInput>`|
 
 Example:
@@ -220,6 +220,22 @@ export let props = {
     value: [10, 0, 5],
     hidden: __BUILD__,
   }
+}
+```
+
+A prop can `disabled` so it stays in the UI but inputs are disabled to display a constraint. It also works with a function to toggle the disabled state depending on other changes (another prop changes for example).
+
+```js
+export let props = {
+  display: {
+    value: true,
+    disabled: false,
+  },
+  color: {
+    value: [10, 0, 5],
+    disabled: () => props.display.value === false,
+  },
+
 }
 ```
 

--- a/src/client/app/modules/MidiPanel.svelte
+++ b/src/client/app/modules/MidiPanel.svelte
@@ -1,106 +1,105 @@
 <script>
-import { onMount } from "svelte";
-import Module from "../ui/Module.svelte";
-import Field from "../ui/Field.svelte";
-import MIDI from "../inputs/MIDI.js";
+	import { onMount } from 'svelte';
+	import Module from '../ui/Module.svelte';
+	import Field from '../ui/Field.svelte';
+	import MIDI from '../inputs/MIDI.js';
 
-export let mID;
-export let hasHeader;
+	export let mID;
+	export let hasHeader;
 
-let input, output;
-let inputs = [], outputs = [];
+	let input, output;
+	let inputs = [],
+		outputs = [];
 
-function createDeviceOptions(deviceMap = new Map()) {
-    let options = [];
+	function createDeviceOptions(deviceMap = new Map()) {
+		let options = [];
 
-    if (deviceMap.size !== 0) {
-        options.push({ value: "none", label: "No device selected." });
-    }
+		if (deviceMap.size !== 0) {
+			options.push({ value: 'none', label: 'No device selected.' });
+		}
 
-    for (let entry of deviceMap) {
-        let device = entry[1];
-        const { id, name, manufacturer } = device;
+		for (let entry of deviceMap) {
+			let device = entry[1];
+			const { id, name, manufacturer } = device;
 
-        options.push({ value: id, label: `${manufacturer} ${name} – id: ${id}` });
-    }
+			options.push({
+				value: id,
+				label: `${manufacturer} ${name} – id: ${id}`,
+			});
+		}
 
-    if (options.length === 0) {
-        options = [
-            { value: "none", label: "No device detected."}
-        ];
-    }
+		if (options.length === 0) {
+			options = [{ value: 'none', label: 'No device detected.' }];
+		}
 
-    return options;
-}
+		return options;
+	}
 
-let messages = [];
+	let messages = [];
 
-$: {
-    MIDI.selectedInputID = input;
-}
+	$: {
+		MIDI.selectedInputID = input;
+	}
 
-$: {
-    MIDI.selectedOutputID = output;
-}
+	$: {
+		MIDI.selectedOutputID = output;
+	}
 
-onMount(async () => {
-    await MIDI.request();
+	onMount(async () => {
+		await MIDI.request();
 
-    function refresh() {
-        inputs = createDeviceOptions(MIDI.inputs);
-        outputs = createDeviceOptions(MIDI.outputs);
+		function refresh() {
+			inputs = createDeviceOptions(MIDI.inputs);
+			outputs = createDeviceOptions(MIDI.outputs);
 
-        // if a single device is connected, select it by default
-        input = (inputs.length === 2 ? inputs[1].value : inputs[0].value);
-        output = (outputs.length === 2 ? outputs[1].value : outputs[0].value);
-    }
+			// if a single device is connected, select it by default
+			input = inputs.length === 2 ? inputs[1].value : inputs[0].value;
+			output = outputs.length === 2 ? outputs[1].value : outputs[0].value;
+		}
 
-    MIDI.addEventListener("connected", refresh);
-    MIDI.addEventListener("disconnected", () => {
-        refresh();
-    });
+		MIDI.addEventListener('connected', refresh);
+		MIDI.addEventListener('disconnected', () => {
+			refresh();
+		});
 
-    MIDI.addEventListener("message", (event) => {
-        const { type, note, channel, value } = event;
-        let date = new Date();
-        let time = `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`;
+		MIDI.addEventListener('message', (event) => {
+			const { type, note, channel, value } = event;
+			let date = new Date();
+			let time = `${date.getHours()}:${String(date.getMinutes()).padStart(
+				2,
+				'0',
+			)}:${String(date.getSeconds()).padStart(2, '0')}`;
 
-        let noteLog = ["noteon", "noteoff"].includes(type) ? ` note:${note.name}` : ``; 
+			let noteLog = ['noteon', 'noteoff'].includes(type)
+				? ` note:${note.name}`
+				: ``;
 
-        messages = [
-            ...messages,
-            `${time} ${type} number:${note.number}${noteLog}`,
-        ]
-    });
+			messages = [
+				...messages,
+				`${time} ${type} number:${note.number}${noteLog}`,
+			];
+		});
 
-    refresh();
-});
-
+		refresh();
+	});
 </script>
 
 <Module {mID} {hasHeader} name="MIDI" {...$$props} slug="midi">
-    <Field
-        key="inputs"
-        value={input}
-        on:change={(event) => input = event.detail}
-        params={{
-            options: inputs,
-        }}
-    />
-    <Field
-        key="outputs"
-        value={output}
-        on:change={(event) => output = event.detail}
-        params={{
-            options: outputs,
-        }}
-    />
-    <Field
-        key="messages"
-        value={messages}
-        type="list"
-        params={{
-            disabled: true
-        }}
-    />
+	<Field
+		key="inputs"
+		value={input}
+		on:change={(event) => (input = event.detail)}
+		params={{
+			options: inputs,
+		}}
+	/>
+	<Field
+		key="outputs"
+		value={output}
+		on:change={(event) => (output = event.detail)}
+		params={{
+			options: outputs,
+		}}
+	/>
+	<Field key="messages" value={messages} type="list" disabled />
 </Module>

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -1,112 +1,131 @@
 <script context="module">
-import { writable } from "svelte/store";
+	import { writable } from 'svelte/store';
 
-export const params = writable([]);
+	export const params = writable([]);
 
-let ID = 0;
-
+	let ID = 0;
 </script>
 
 <script>
-import { onMount, onDestroy } from "svelte";
-import { props } from "../stores";
-import { sketches } from "../stores/sketches.js";
-import { monitors } from "../stores/rendering";
-import Module from "../ui/Module.svelte";
-import Field from "../ui/Field.svelte";
-import OutputParams from "../ui/ParamsOutput.svelte";
-import ModuleHeaderAction from "../ui/ModuleHeaderAction.svelte";
+	import { onMount, onDestroy } from 'svelte';
+	import { props } from '../stores';
+	import { sketches } from '../stores/sketches.js';
+	import { monitors } from '../stores/rendering';
+	import Module from '../ui/Module.svelte';
+	import Field from '../ui/Field.svelte';
+	import OutputParams from '../ui/ParamsOutput.svelte';
+	import ModuleHeaderAction from '../ui/ModuleHeaderAction.svelte';
 
-export let mID;
-export let hasHeader = true;
-export let output = true;
+	export let mID;
+	export let hasHeader = true;
+	export let output = true;
 
-let id = ID++;
-let selected = id;
-let sketch, sketchKey, sketchProps = {};
-let monitor, showOutputParams;
+	let id = ID++;
+	let selected = id;
+	let sketch,
+		sketchKey,
+		sketchProps = {};
+	let monitor, showOutputParams;
 
-onMount(() => {
-    $params = [
-        ...$params,
-        {
-            id,
-        }
-    ];
-});
+	onMount(() => {
+		$params = [
+			...$params,
+			{
+				id,
+			},
+		];
+	});
 
-onDestroy(() => {
-    $params = $params.filter((p) => p.id !== id);
-});
+	onDestroy(() => {
+		$params = $params.filter((p) => p.id !== id);
+	});
 
-$: options = [
-    ...$monitors.map((monitor, index) => {
-        return { value: index, label: `monitor ${index + 1}`}
-    }),
-    ...$params.length > 1 ? [{ value: "output", label: "output"}] : [],
-];
+	$: options = [
+		...$monitors.map((monitor, index) => {
+			return { value: index, label: `monitor ${index + 1}` };
+		}),
+		...($params.length > 1 ? [{ value: 'output', label: 'output' }] : []),
+	];
 
-monitors.subscribe((value) => {
-    monitor = $monitors[Math.min(selected, $monitors.length - 1)];
-    sketchKey = monitor ? monitor.selected : undefined;
-});
+	monitors.subscribe((value) => {
+		monitor = $monitors[Math.min(selected, $monitors.length - 1)];
+		sketchKey = monitor ? monitor.selected : undefined;
+	});
 
-$: {
-    sketch = $sketches[sketchKey];
-    sketchProps = $props[sketchKey];
-}
+	$: {
+		sketch = $sketches[sketchKey];
+		sketchProps = $props[sketchKey];
+	}
 
-$: showOutputParams = (monitor && monitor.selected === "output") ||
-        ($params.length === 1) ||
-        (selected === "output");
-
+	$: showOutputParams =
+		(monitor && monitor.selected === 'output') ||
+		$params.length === 1 ||
+		selected === 'output';
 </script>
 
-<Module {mID} {hasHeader} name={`Parameters`} slug="params" >
-    <div slot="header-right">
-        {#if options.length > 1 }
-        <ModuleHeaderAction
-            value={selected}
-            permanent
-            border
-            on:change={(event) => selected = event.detail}
-            options={options}
-        />
-        {/if }
-    </div>
-    {#if showOutputParams && output }
-        <OutputParams />
-    {/if}
+<Module {mID} {hasHeader} name={`Parameters`} slug="params">
+	<div slot="header-right">
+		{#if options.length > 1}
+			<ModuleHeaderAction
+				value={selected}
+				permanent
+				border
+				on:change={(event) => (selected = event.detail)}
+				{options}
+			/>
+		{/if}
+	</div>
+	{#if showOutputParams && output}
+		<OutputParams />
+	{/if}
 
-    {#if sketch }
-        {#if typeof props === "object"}
-            {#if output}
-                <Field key="framerate" value={isFinite(sketch.fps) ? sketch.fps : 60} params={{disabled: true}}/>
-            {/if}
-            {#if sketch.duration && sketch.duration > 0 && output }
-                <Field key="duration" value={sketch.duration} params={{disabled: true, suffix: "s"}}/>
-            {/if }
-            {#each Object.keys(sketchProps) as key, i}
-                {#if !sketchProps[key].hidden}
-                <Field
-                    context={sketchKey}
-                    key={key}
-                    value={sketchProps[key].value}
-                    type={sketchProps[key].type}
-                    bind:params={sketchProps[key].params}
-                    on:click={() => {
-                        $props[sketchKey][key].value._refresh = true;
-                    }}
-                    on:change={(event) => {
-                        $props[sketchKey][key].value = event.detail;
+	{#if sketch}
+		{#if typeof props === 'object'}
+			{#if output}
+				<Field
+					key="framerate"
+					value={isFinite(sketch.fps) ? sketch.fps : 60}
+					disabled
+				/>
+			{/if}
+			{#if sketch.duration && sketch.duration > 0 && output}
+				<Field
+					key="duration"
+					value={sketch.duration}
+					params={{ suffix: 's' }}
+					disabled
+				/>
+			{/if}
+			{#each Object.keys(sketchProps) as key, i}
+				{#if !sketchProps[key].hidden}
+					<Field
+						context={sketchKey}
+						{key}
+						value={sketchProps[key].value}
+						type={sketchProps[key].type}
+						disabled={typeof sketchProps[key].disabled ===
+						'function'
+							? sketchProps[key].disabled()
+							: sketchProps[key].disabled}
+						bind:params={sketchProps[key].params}
+						on:click={() => {
+							$props[sketchKey][key].value._refresh = true;
+						}}
+						on:change={(event) => {
+							$props[sketchKey][key].value = event.detail;
 
-                        if (typeof $props[sketchKey][key].onChange === 'function') {
-                            $props[sketchKey][key].onChange($props[sketchKey][key]);
-                        }
-                    }}
-                />
-                {/if}
-            {/each}
-        {/if}
-    {/if}
+							if (
+								typeof $props[sketchKey][key].onChange ===
+								'function'
+							) {
+								$props[sketchKey][key].onChange(
+									$props[sketchKey][key],
+								);
+							}
+						}}
+					/>
+				{/if}
+			{/each}
+		{/if}
+	{/if}
 </Module>

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -1,266 +1,372 @@
 <script>
-import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from 'svelte';
 
-import Select from "./fields/Select.svelte";
-import NumberInput from "./fields/NumberInput.svelte";
-import CheckboxInput from "./fields/CheckboxInput.svelte";
-import VectorInput from "./fields/VectorInput.svelte";
-import TextInput from "./fields/TextInput.svelte";
-import ColorInput from "./fields/ColorInput.svelte";
-import ListInput from "./fields/ListInput.svelte";
-import ButtonInput from "./fields/ButtonInput.svelte";
-import ImageInput from "./fields/ImageInput.svelte";
-import FieldSection from "./FieldSection.svelte";
-import FieldTriggers from "./FieldTriggers.svelte";
-import { inferFromParams, inferFromValue } from "../utils/props.utils.js";
-import { download } from "../utils/file.utils.js";
-import { map } from "../utils/math.utils";
-import frameDebounce from "../lib/helpers/frameDebounce.js";
-import { getStore } from "../stores/utils";
-import { writable } from "svelte/store";
+	import Select from './fields/Select.svelte';
+	import NumberInput from './fields/NumberInput.svelte';
+	import CheckboxInput from './fields/CheckboxInput.svelte';
+	import VectorInput from './fields/VectorInput.svelte';
+	import TextInput from './fields/TextInput.svelte';
+	import ColorInput from './fields/ColorInput.svelte';
+	import ListInput from './fields/ListInput.svelte';
+	import ButtonInput from './fields/ButtonInput.svelte';
+	import ImageInput from './fields/ImageInput.svelte';
+	import FieldSection from './FieldSection.svelte';
+	import FieldTriggers from './FieldTriggers.svelte';
+	import { inferFromParams, inferFromValue } from '../utils/props.utils.js';
+	import { download } from '../utils/file.utils.js';
+	import { map } from '../utils/math.utils';
+	import frameDebounce from '../lib/helpers/frameDebounce.js';
+	import { getStore } from '../stores/utils';
+	import { writable } from 'svelte/store';
 
-export let key = "";
-export let value = null;
-export let context = null;
-export let params = {};
-export let type = null;
+	export let key = '';
+	export let value = null;
+	export let context = null;
+	export let params = {};
+	export let type = null;
+	export let disabled = false;
 
-let offsetWidth;
-let showTriggers = false;
+	let offsetWidth;
+	let showTriggers = false;
 
-const store = getStore(context, { props: {}}, {
-    persist: context !== null,
-});
+	const store = getStore(
+		context,
+		{ props: {} },
+		{
+			persist: context !== null,
+		},
+	);
 
-if (!$store.props[key]) {
-    $store.props[key] = { triggers: [] };
-}
+	if (!$store.props[key]) {
+		$store.props[key] = { triggers: [] };
+	}
 
-let triggers = writable($store.props[key].triggers.filter((trigger) => trigger.inputType !== undefined));
-triggers.subscribe((all) => {
-    store.update((curr) => {
-        curr.props[key].triggers = all;
+	let triggers = writable(
+		$store.props[key].triggers.filter(
+			(trigger) => trigger.inputType !== undefined,
+		),
+	);
+	triggers.subscribe((all) => {
+		store.update((curr) => {
+			curr.props[key].triggers = all;
 
-        return curr;
-    });
-})
+			return curr;
+		});
+	});
 
-const dispatch = createEventDispatcher();
-const fields = {
-    "select": Select,
-    "number": NumberInput,
-    "vec": VectorInput,
-    "checkbox": CheckboxInput,
-    "text": TextInput,
-    "list": ListInput,
-    "color": ColorInput,
-    "button": ButtonInput,
-    "download": ButtonInput,
-    "image": ImageInput,
-};
+	const dispatch = createEventDispatcher();
+	const fields = {
+		select: Select,
+		number: NumberInput,
+		vec: VectorInput,
+		checkbox: CheckboxInput,
+		text: TextInput,
+		list: ListInput,
+		color: ColorInput,
+		button: ButtonInput,
+		download: ButtonInput,
+		image: ImageInput,
+	};
 
-const onTriggers = {
-    'checkbox': () => {
-        value = !value;
+	const onTriggers = {
+		checkbox: () => {
+			value = !value;
 
-        dispatch('change', value);
-    },
-    'button': (event) => {
-        value(event);
-        dispatch('click', event);
-    },
-    'download': (event) => {
-        let [data, filename] = value(event);
+			dispatch('change', value);
+		},
+		button: (event) => {
+			value(event);
+			dispatch('click', event);
+		},
+		download: (event) => {
+			let [data, filename] = value(event);
 
-        download(data, filename);
-    },
-    'number': (event = {}) => {
-        const isValueInRange = event.value >= 0 && event.value <= 1;
+			download(data, filename);
+		},
+		number: (event = {}) => {
+			const isValueInRange = event.value >= 0 && event.value <= 1;
 
-        if (isValueInRange && isFinite(params.min) && isFinite(params.max)) {
-            let v = map(event.value, 0, 1, params.min, params.max);
-            let step = params.step ? params.step : 1;
-            let value = Math.round(v * (1 / step)) / (1 / step);
+			if (
+				isValueInRange &&
+				isFinite(params.min) &&
+				isFinite(params.max)
+			) {
+				let v = map(event.value, 0, 1, params.min, params.max);
+				let step = params.step ? params.step : 1;
+				let value = Math.round(v * (1 / step)) / (1 / step);
 
-            dispatch('change', value);
-        }
-    },
-};
+				dispatch('change', value);
+			}
+		},
+	};
 
-$: fieldType = type ? type : (inferFromParams(params) || inferFromValue(value));
-$: fieldProps = composeFieldProps(params);
-$: onTrigger = frameDebounce(onTriggers[fieldType]);
-$: input = fields[fieldType];
-$: label = params.label !== undefined && typeof value !== "function" ? params.label : key;
-$: disabled = params.disabled;
-$: triggerable = params.triggerable !== false && (
-    (fieldType === "number" && isFinite(params.min) && isFinite(params.max)) ||
-    (fieldType === "button")
-);
-$: {
-    if (fieldType === "download" || fieldType === "button") {
-        if (params.label === undefined) {
-            fieldProps.label = fieldType === "download" ? "download" : "run";
-        }
-    }
-}
-$: xxsmall = offsetWidth < 200;
-$: xsmall = !xxsmall && offsetWidth < 260;
-$: small = !xxsmall && !xsmall && offsetWidth < 320;
-$: triggersActive = $triggers.length > 0;
+	$: fieldType = type
+		? type
+		: inferFromParams(params) || inferFromValue(value);
+	$: fieldProps = composeFieldProps(params, disabled);
+	$: onTrigger = frameDebounce(onTriggers[fieldType]);
+	$: input = fields[fieldType];
+	$: label =
+		params.label !== undefined && typeof value !== 'function'
+			? params.label
+			: key;
+	$: triggerable =
+		params.triggerable !== false &&
+		((fieldType === 'number' &&
+			isFinite(params.min) &&
+			isFinite(params.max)) ||
+			fieldType === 'button');
+	$: {
+		if (fieldType === 'download' || fieldType === 'button') {
+			if (params.label === undefined) {
+				fieldProps.label =
+					fieldType === 'download' ? 'download' : 'run';
+			}
+		}
+	}
+	$: xxsmall = offsetWidth < 200;
+	$: xsmall = !xxsmall && offsetWidth < 260;
+	$: small = !xxsmall && !xsmall && offsetWidth < 320;
+	$: triggersActive = $triggers.length > 0;
 
-function toggleTriggers(event) {
-    event.preventDefault();
+	function toggleTriggers(event) {
+		event.preventDefault();
 
-    showTriggers = !showTriggers;
-}
+		showTriggers = !showTriggers;
+	}
 
-function composeFieldProps(params) {
-    const { triggerable, controllable, ...rest } = params;
+	function composeFieldProps(params, disabled) {
+		const { triggerable, controllable, ...rest } = params;
 
-    return {
-        ...rest,
-        key,
-        context,
-    };
-}
-
+		return {
+			...rest,
+			disabled,
+			key,
+			context,
+		};
+	}
 </script>
 
-<div class="field"
-    class:disabled={disabled}
-    class:xxsmall={xxsmall}
-    class:xsmall={xsmall}
-    class:small={small}
-    bind:offsetWidth={offsetWidth}
+<div
+	class="field"
+	class:disabled
+	class:xxsmall
+	class:xsmall
+	class:small
+	bind:offsetWidth
 >
-    <FieldSection name={key} label={label} interactive={triggerable} on:click={toggleTriggers}>
-        <div slot="infos" class="field__actions">
-            {#if triggerable && !disabled }
-                <button
-                    on:click={toggleTriggers}
-                    class="field__action field__action--triggers"
-                    class:active={triggersActive}>
-                    <svg width="16" height="16" fill="none" viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 8H7.25"/>
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12.75 8H19.25"/>
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.75 16H12.25"/>
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17.75 16H19.25"/>
-                        <circle cx="10" cy="8" r="2.25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
-                        <circle cx="15" cy="16" r="2.25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
-                    </svg>
-                </button>
-            {/if}
-            {#if (fieldType === "vec") && !disabled }
-                <button class="field__action field__action--lock" on:click={() => params.locked = !params.locked}>
-                    {#if params.locked}
-                    <svg class="action__icon" width="16" height="16" fill="none" viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"></path>
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.75 10.5V10.3427C7.75 8.78147 7.65607 7.04125 8.74646 5.9239C9.36829 5.2867 10.3745 4.75 12 4.75C13.6255 4.75 14.6317 5.2867 15.2535 5.9239C16.3439 7.04125 16.25 8.78147 16.25 10.3427V10.5"></path>
-                    </svg>
-                    {:else}
-                    <svg class="action__icon" width="16" height="16" fill="none" viewBox="0 0 24 24">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"></path>
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.75 10.5V9.84343C7.75 8.61493 7.70093 7.29883 8.42416 6.30578C8.99862 5.51699 10.0568 4.75 12 4.75C14 4.75 15.25 6.25 15.25 6.25"></path>
-                    </svg>
-                    {/if}
-                </button>
-            {/if}
-        </div>
-        <svelte:component
-            this={input}
-            {value}
-            {...fieldProps}
-            on:change
-            on:click={onTrigger}
-        />
-        <slot></slot>
-    </FieldSection>
-    {#if triggerable }
-        <FieldSection visible={showTriggers} secondary>
-            <FieldTriggers
-                {triggers}
-                {onTrigger}
-                {context}
-                triggerable={fieldType === "button"}
-                controllable={fieldType === "number"}
-            />
-        </FieldSection>
-    {/if}
+	<FieldSection
+		name={key}
+		{label}
+		interactive={triggerable}
+		on:click={toggleTriggers}
+		{disabled}
+	>
+		<div slot="infos" class="field__actions">
+			{#if triggerable && !disabled}
+				<button
+					on:click={toggleTriggers}
+					class="field__action field__action--triggers"
+					class:active={triggersActive}
+				>
+					<svg width="16" height="16" fill="none" viewBox="0 0 24 24">
+						<path
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+							d="M4.75 8H7.25"
+						/>
+						<path
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+							d="M12.75 8H19.25"
+						/>
+						<path
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+							d="M4.75 16H12.25"
+						/>
+						<path
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+							d="M17.75 16H19.25"
+						/>
+						<circle
+							cx="10"
+							cy="8"
+							r="2.25"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+						/>
+						<circle
+							cx="15"
+							cy="16"
+							r="2.25"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.5"
+						/>
+					</svg>
+				</button>
+			{/if}
+			{#if fieldType === 'vec' && !disabled}
+				<button
+					class="field__action field__action--lock"
+					on:click={() => (params.locked = !params.locked)}
+				>
+					{#if params.locked}
+						<svg
+							class="action__icon"
+							width="16"
+							height="16"
+							fill="none"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="1.5"
+								d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"
+							/>
+							<path
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="1.5"
+								d="M7.75 10.5V10.3427C7.75 8.78147 7.65607 7.04125 8.74646 5.9239C9.36829 5.2867 10.3745 4.75 12 4.75C13.6255 4.75 14.6317 5.2867 15.2535 5.9239C16.3439 7.04125 16.25 8.78147 16.25 10.3427V10.5"
+							/>
+						</svg>
+					{:else}
+						<svg
+							class="action__icon"
+							width="16"
+							height="16"
+							fill="none"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="1.5"
+								d="M5.75 11.75C5.75 11.1977 6.19772 10.75 6.75 10.75H17.25C17.8023 10.75 18.25 11.1977 18.25 11.75V17.25C18.25 18.3546 17.3546 19.25 16.25 19.25H7.75C6.64543 19.25 5.75 18.3546 5.75 17.25V11.75Z"
+							/>
+							<path
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="1.5"
+								d="M7.75 10.5V9.84343C7.75 8.61493 7.70093 7.29883 8.42416 6.30578C8.99862 5.51699 10.0568 4.75 12 4.75C14 4.75 15.25 6.25 15.25 6.25"
+							/>
+						</svg>
+					{/if}
+				</button>
+			{/if}
+		</div>
+		<svelte:component
+			this={input}
+			{value}
+			{...fieldProps}
+			on:change
+			on:click={onTrigger}
+		/>
+		<slot />
+	</FieldSection>
+	{#if triggerable}
+		<FieldSection visible={showTriggers} secondary>
+			<FieldTriggers
+				{triggers}
+				{onTrigger}
+				{context}
+				triggerable={fieldType === 'button'}
+				controllable={fieldType === 'number'}
+			/>
+		</FieldSection>
+	{/if}
 </div>
 
 <style>
-.field {
-    --column-gap: 3px;
-    --padding: 6px;
+	.field {
+		--column-gap: 3px;
+		--padding: 6px;
 
-    width: 100%;
+		width: 100%;
 
-    padding: 3px 6px 3px 12px;
-    border-bottom: 1px solid var(--color-spacing);
-}
+		padding: 3px 6px 3px 12px;
+		border-bottom: 1px solid var(--color-spacing);
+	}
 
-:global(.field__input .field) {
-    padding-left: 0px !important;
-    padding-right: 0px !important;
-}
+	:global(.field__input .field) {
+		padding-left: 0px !important;
+		padding-right: 0px !important;
+	}
 
-:global(.field__input .field:last-child) {
-    border-bottom: 0px solid #323233 !important;
-    padding-bottom: 0px !important;
-    
-}
+	:global(.field__input .field:last-child) {
+		border-bottom: 0px solid #323233 !important;
+		padding-bottom: 0px !important;
+	}
 
-.field.disabled {
-    pointer-events: none;
-}
+	.field.disabled {
+		pointer-events: none;
+	}
 
-.field__actions {
-    display: flex;
-    align-items: center;
-}
+	.field__actions {
+		display: flex;
+		align-items: center;
+	}
 
-.field__action {
-    display: flex;
-    align-items: center;
+	.field__action {
+		display: flex;
+		align-items: center;
 
-    background: transparent;
-    transition: opacity 0.1s ease;
-}
+		background: transparent;
+		transition: opacity 0.1s ease;
+	}
 
-.field__action:hover {
-    opacity: 1;
-}
+	.field__action:hover {
+		opacity: 1;
+	}
 
-.field__action--triggers {
-    --background-color: rgba(255, 255, 255, 0.5);
+	.field__action--triggers {
+		--background-color: rgba(255, 255, 255, 0.5);
 
-    position: relative;
+		position: relative;
 
-    width: 16px;
-    height: 16px;
+		width: 16px;
+		height: 16px;
 
-    background-color: transparent;
-    cursor: pointer;
-}
+		background-color: transparent;
+		cursor: pointer;
+	}
 
-.field__action--triggers:not(.active) {
-    display: none;
-}
+	.field__action--triggers:not(.active) {
+		display: none;
+	}
 
-.field__action {
-    color: var(--color-text);
+	.field__action {
+		color: var(--color-text);
 
-    opacity: 0.6;
-    background-color: transparent;
-    transition: opacity 0.1s ease;
-}
+		opacity: 0.6;
+		background-color: transparent;
+		transition: opacity 0.1s ease;
+	}
 
-.field__action--triggers svg {
-    transform: rotate(90deg);
-}
+	.field__action--triggers svg {
+		transform: rotate(90deg);
+	}
 
-.field__action:hover {
-    opacity: 1;
-}
+	.field__action:hover {
+		opacity: 1;
+	}
 </style>

--- a/src/client/app/ui/FieldSection.svelte
+++ b/src/client/app/ui/FieldSection.svelte
@@ -1,123 +1,131 @@
 <script>
-export let visible = true;
-export let secondary = false;
-export let interactive = false;
-export let label = "";
-export let name = "";
+	export let visible = true;
+	export let secondary = false;
+	export let interactive = false;
+	export let label = '';
+	export let name = '';
+	export let disabled = false;
 </script>
 
-<div class="field__section" class:visible={visible} class:secondary={secondary} class:no-label={label === null}>
-    <div class="field__infos">
-        {#if label !== null}
-            {#if interactive}
-                <button class="field__label" on:click>{label}</button>
-            {:else}
-                <span class="field__label">{label}</span>
-            {/if}
-        {/if}
-        <slot name="infos"></slot>
-    </div>
-    <div class="field__input">
-        <slot></slot>
-    </div>
+<div
+	class="field__section"
+	class:visible
+	class:secondary
+	class:no-label={label === null}
+>
+	<div class="field__infos">
+		{#if label !== null}
+			{#if interactive}
+				<button class="field__label" {disabled} on:click>{label}</button
+				>
+			{:else}
+				<span class="field__label">{label}</span>
+			{/if}
+		{/if}
+		<slot name="infos" />
+	</div>
+	<div class="field__input">
+		<slot />
+	</div>
 </div>
 
 <style>
-.field__section {
-    position: relative;
-    
-    display: grid;
-    grid-template-columns: 0.5fr 1fr;
-    column-gap: 10px;
-}
+	.field__section {
+		position: relative;
 
-.field__section.no-label {
-    grid-template-columns: 1fr;
-}
+		display: grid;
+		grid-template-columns: 0.5fr 1fr;
+		column-gap: 10px;
+	}
 
-.field__section:hover .field__label, .field__section:focus-within .field__label {
-    opacity: 1;
-}
+	.field__section.no-label {
+		grid-template-columns: 1fr;
+	}
 
-.field__section:not(.visible) {
-    display: none;
-}
+	.field__section:hover .field__label,
+	.field__section:focus-within .field__label {
+		opacity: 1;
+	}
 
-.field__section.secondary {
-    --margin: 15px;
+	.field__section:not(.visible) {
+		display: none;
+	}
 
-    grid-template-columns: 0.25fr 1fr;
-    margin-top: var(--margin);
-}
+	.field__section.secondary {
+		--margin: 15px;
 
-.field__section.secondary:before {
-    content: '';
+		grid-template-columns: 0.25fr 1fr;
+		margin-top: var(--margin);
+	}
 
-    position: absolute;
-    left: 10px;
-    top: calc(var(--margin) * -1);
+	.field__section.secondary:before {
+		content: '';
 
-    width: 1px;
-    height: var(--margin);
-    
-    background-color: var(--color-spacing);
-}
+		position: absolute;
+		left: 10px;
+		top: calc(var(--margin) * -1);
 
-.field__infos {
-    position: relative;
+		width: 1px;
+		height: var(--margin);
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    
-    color: var(--color-text);
-}
+		background-color: var(--color-spacing);
+	}
 
-.field__label {
-    color: inherit;
-    font-size: var(--font-size-input);
-    user-select: none;
+	.field__infos {
+		position: relative;
 
-    opacity: 0.6;
-    background-color: transparent;
-    transition: opacity 0.1s ease;
-}
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 
-button.field__label {
-    cursor: pointer;
-}
+		color: var(--color-text);
+	}
 
-.field__label:focus-visible {
-    outline: 0;
-    box-shadow: 0 0 0 2px var(--color-text);
-    border-radius: 2px;
-}
+	.field__label {
+		color: inherit;
+		font-size: var(--font-size-input);
+		user-select: none;
 
-.field__section.secondary {
-    grid-template-columns: 1fr;
-}
+		opacity: 0.6;
+		background-color: transparent;
+		transition: opacity 0.1s ease;
+	}
 
-.field__section.secondary .field__infos {
-    display: none;
-}
+	button.field__label {
+		cursor: pointer;
+	}
 
-.field__section.secondary .field__label {
-    position: relative;
+	.field__label:focus-visible {
+		outline: 0;
+		box-shadow: 0 0 0 2px var(--color-text);
+		border-radius: 2px;
+	}
 
-    padding-left: 5px;
+	.field__section.secondary {
+		grid-template-columns: 1fr;
+	}
 
-    background-color: #242425;
-}
+	.field__section.secondary .field__infos {
+		display: none;
+	}
 
-.field__input {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: flex-start;
-}
+	.field__section.secondary .field__label {
+		position: relative;
 
-.field__section.secondary .field__input {
-    padding: var(--column-gap);
-    border: 1px solid var(--color-spacing);
-}
+		padding-left: 5px;
+
+		background-color: #242425;
+	}
+
+	.field__input {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: flex-start;
+	}
+
+	.field__section.secondary .field__input {
+		padding: var(--column-gap);
+		border: 1px solid var(--color-spacing);
+	}
 </style>

--- a/src/client/app/ui/ParamsMultisampling.svelte
+++ b/src/client/app/ui/ParamsMultisampling.svelte
@@ -1,109 +1,110 @@
 <script>
-import { multisampling, threshold, transition } from "../stores/multisampling.js";
-import { monitors } from "../stores/rendering.js";
-import { transitions } from "../transitions/index.js";
-import Field from "./Field.svelte";
-import FieldGroup from "./FieldGroup.svelte";
+	import {
+		multisampling,
+		threshold,
+		transition,
+	} from '../stores/multisampling.js';
+	import { monitors } from '../stores/rendering.js';
+	import { transitions } from '../transitions/index.js';
+	import Field from './Field.svelte';
+	import FieldGroup from './FieldGroup.svelte';
 
-let monitorDisabled = false;
-let sampler0 = -1;
-let sampler1 = -1;
+	let monitorDisabled = false;
+	let sampler0 = -1;
+	let sampler1 = -1;
 
-const transitionOptions = Object.keys(transitions).map((key) => {
-    const transition = transitions[key];
-    const label = transition.name ? transition.name : key;
-    return { value: key, label };
-});
-
-if (!$transition) {
-    $transition = transitionOptions[0].value;
-}
-
-$: samplerOptions = $monitors
-	.map((monitor, index) => ({ label: `monitor ${index+1}`, value: monitor.id })) // set index first so it matches <Monitor>
-    .filter((option) => {
-		const monitor = $monitors.find((m) => m.id === option.value);
-
-		return monitor.selected !== "output";
+	const transitionOptions = Object.keys(transitions).map((key) => {
+		const transition = transitions[key];
+		const label = transition.name ? transition.name : key;
+		return { value: key, label };
 	});
-$: {
-    monitorDisabled = samplerOptions.length === 0;
 
-    if (samplerOptions.length === 0) {
-        samplerOptions = [
-            { label: `No monitor available.`, value: -1 }
-        ];
-        sampler0 = samplerOptions[0].value;
-        sampler1 = samplerOptions[0].value;
-    } else {
-        if (sampler0 < 0) {
-            sampler0 = samplerOptions[0].value;
-        }
+	if (!$transition) {
+		$transition = transitionOptions[0].value;
+	}
 
-        if (sampler1 < 0) {
-            sampler1 = samplerOptions.length > 1 ? samplerOptions[1].value : -1;
-        }
-    }
+	$: samplerOptions = $monitors
+		.map((monitor, index) => ({
+			label: `monitor ${index + 1}`,
+			value: monitor.id,
+		})) // set index first so it matches <Monitor>
+		.filter((option) => {
+			const monitor = $monitors.find((m) => m.id === option.value);
 
-    $multisampling = [sampler0, sampler1];
-}
+			return monitor.selected !== 'output';
+		});
+	$: {
+		monitorDisabled = samplerOptions.length === 0;
 
+		if (samplerOptions.length === 0) {
+			samplerOptions = [{ label: `No monitor available.`, value: -1 }];
+			sampler0 = samplerOptions[0].value;
+			sampler1 = samplerOptions[0].value;
+		} else {
+			if (sampler0 < 0) {
+				sampler0 = samplerOptions[0].value;
+			}
+
+			if (sampler1 < 0) {
+				sampler1 =
+					samplerOptions.length > 1 ? samplerOptions[1].value : -1;
+			}
+		}
+
+		$multisampling = [sampler0, sampler1];
+	}
 </script>
+
 <FieldGroup name="monitors">
-    <Field
-        key="sampler0"
-        value={sampler0}
-        on:change={event => {
-            sampler0 = Number(event.detail);
-        }}
-        params={
-            {
-                options: samplerOptions,
-                disabled: monitorDisabled
-            }
-        }
-    />
-    <Field
-        key="sampler1"
-        value={sampler1}
-        on:change={event => {
-            sampler1 = Number(event.detail);
-        }}
-        params={
-            {
-                options: samplerOptions,
-                disabled: monitorDisabled
-            }
-        }
-    />
+	<Field
+		key="sampler0"
+		value={sampler0}
+		on:change={(event) => {
+			sampler0 = Number(event.detail);
+		}}
+		params={{
+			options: samplerOptions,
+		}}
+		disabled={monitorDisabled}
+	/>
+	<Field
+		key="sampler1"
+		value={sampler1}
+		on:change={(event) => {
+			sampler1 = Number(event.detail);
+		}}
+		params={{
+			options: samplerOptions,
+		}}
+		disabled={monitorDisabled}
+	/>
 </FieldGroup>
 <FieldGroup name="transition">
-    <Field
-        key="type"
-        value={$transition}
-        on:change={(event) => {
-            $transition = event.detail;
-        }}
-        params={{
-            options: transitionOptions,
-        }}
-    />
-    <Field
-        key="threshold"
-        value={$threshold}
-        on:change={(event) => $threshold = event.detail }
-        params={{
-            step: 0.01,
-            min: 0,
-            max: 1,
-        }}
-    />
-    <Field
-        key="switch"
-        value={() => $threshold = 1 - Math.round($threshold)}
-        params={{
-            label: `switch ${Math.round($threshold) > 0 ? `<` : `>`}`
-        }}
-    />
-    
+	<Field
+		key="type"
+		value={$transition}
+		on:change={(event) => {
+			$transition = event.detail;
+		}}
+		params={{
+			options: transitionOptions,
+		}}
+	/>
+	<Field
+		key="threshold"
+		value={$threshold}
+		on:change={(event) => ($threshold = event.detail)}
+		params={{
+			step: 0.01,
+			min: 0,
+			max: 1,
+		}}
+	/>
+	<Field
+		key="switch"
+		value={() => ($threshold = 1 - Math.round($threshold))}
+		params={{
+			label: `switch ${Math.round($threshold) > 0 ? `<` : `>`}`,
+		}}
+	/>
 </FieldGroup>

--- a/src/client/app/ui/ParamsOutput.svelte
+++ b/src/client/app/ui/ParamsOutput.svelte
@@ -32,8 +32,6 @@
 		$rendering.resizing,
 	);
 
-	$: console.log({ dimensionsEnabled });
-
 	$: {
 		if ($rendering.resizing === SIZES.PRESET) {
 			const { preset } = $rendering;

--- a/src/client/app/ui/ParamsOutput.svelte
+++ b/src/client/app/ui/ParamsOutput.svelte
@@ -1,139 +1,141 @@
 <script>
-import { rendering, SIZES, monitors } from "../stores/rendering.js";
-import { sketchesCount } from "../stores/sketches.js";
-import Field from "./Field.svelte";
-import presets, { getDimensionsForPreset } from "../lib/presets";
-import { exports } from "../stores";
-import ParamsMultisampling from "./ParamsMultisampling.svelte";
+	import { rendering, SIZES, monitors } from '../stores/rendering.js';
+	import { sketchesCount } from '../stores/sketches.js';
+	import Field from './Field.svelte';
+	import presets, { getDimensionsForPreset } from '../lib/presets';
+	import { exports } from '../stores';
+	import ParamsMultisampling from './ParamsMultisampling.svelte';
 
-let canvasWidth = $rendering.width;
-let canvasHeight = $rendering.height;
+	let canvasWidth = $rendering.width;
+	let canvasHeight = $rendering.height;
 
-function handleChangeDimensions(event) {
-    const [width, height] = event.detail;
-    const needsUpdate = canvasWidth !== width || canvasHeight !== height;
+	function handleChangeDimensions(event) {
+		const [width, height] = event.detail;
+		const needsUpdate = canvasWidth !== width || canvasHeight !== height;
 
-    if (needsUpdate) {
-        canvasWidth = width;
-        canvasHeight = height;
+		if (needsUpdate) {
+			canvasWidth = width;
+			canvasHeight = height;
 
-        rendering.update((curr) => {
-            return {
-                ...curr,
-                width,
-                height
-            }
-        });
-    }
-}
+			rendering.update((curr) => {
+				return {
+					...curr,
+					width,
+					height,
+				};
+			});
+		}
+	}
 
-let sizes = Object.values(SIZES);
-$: dimensionsEnabled = [SIZES.FIXED, SIZES.SCALE].includes($rendering.resizing);
+	let sizes = Object.values(SIZES);
+	$: dimensionsEnabled = [SIZES.FIXED, SIZES.SCALE].includes(
+		$rendering.resizing,
+	);
 
-$: {
-    if ($rendering.resizing === SIZES.PRESET) {
-        const { preset } = $rendering;
-        const [ width, height ] = getDimensionsForPreset(preset, { pixelsPerInch: 300 });
+	$: console.log({ dimensionsEnabled });
 
-        rendering.update((curr) => {
-            return {
-                ...curr,
-                width,
-                height,
-            };
-        });
-    }
-}
+	$: {
+		if ($rendering.resizing === SIZES.PRESET) {
+			const { preset } = $rendering;
+			const [width, height] = getDimensionsForPreset(preset, {
+				pixelsPerInch: 300,
+			});
 
+			rendering.update((curr) => {
+				return {
+					...curr,
+					width,
+					height,
+				};
+			});
+		}
+	}
 </script>
 
 <Field
-    key="dimensions"
-    value={[
-        $rendering.width,
-        $rendering.height,
-    ]}
-    on:change={handleChangeDimensions}
-    params={{
-        step: 1,
-        suffix: "px",
-        locked: false,
-        disabled: !dimensionsEnabled,
-    }}
+	key="dimensions"
+	value={[$rendering.width, $rendering.height]}
+	on:change={handleChangeDimensions}
+	params={{
+		step: 1,
+		suffix: 'px',
+		locked: false,
+	}}
+	disabled={!dimensionsEnabled}
 />
 <Field
-    key="canvasSize"
-    value={$rendering.resizing}
-    on:change={(event) => {
-        const resizing = event.detail;
-        let aspectRatio = 1;
+	key="canvasSize"
+	value={$rendering.resizing}
+	on:change={(event) => {
+		const resizing = event.detail;
+		let aspectRatio = 1;
 
-        if (resizing === SIZES.ASPECT_RATIO) {
-            // compute aspect ratio based on previous props
-            aspectRatio = $rendering.width / $rendering.height;
-        }
+		if (resizing === SIZES.ASPECT_RATIO) {
+			// compute aspect ratio based on previous props
+			aspectRatio = $rendering.width / $rendering.height;
+		}
 
-        $exports.pixelsPerInch = resizing === SIZES.PRESET ? 300 : 72;
+		$exports.pixelsPerInch = resizing === SIZES.PRESET ? 300 : 72;
 
-        rendering.update((curr) => {
-            return {
-                ...curr,
-                resizing,
-                aspectRatio,
-            }
-        });
-    }}
-    params={{
-        options: sizes,
-    }}
+		rendering.update((curr) => {
+			return {
+				...curr,
+				resizing,
+				aspectRatio,
+			};
+		});
+	}}
+	params={{
+		options: sizes,
+	}}
 />
 {#if $rendering.resizing === SIZES.ASPECT_RATIO}
-<Field
-    key="aspectRatio"
-    value={$rendering.aspectRatio}
-    on:change={(event) => {
-        $rendering.aspectRatio = event.detail;
-    }}
-    params={{
-        step: 0.01,
-    }}
-/>
+	<Field
+		key="aspectRatio"
+		value={$rendering.aspectRatio}
+		on:change={(event) => {
+			$rendering.aspectRatio = event.detail;
+		}}
+		params={{
+			step: 0.01,
+		}}
+	/>
 {/if}
 {#if $rendering.resizing === SIZES.SCALE}
-<Field
-    key="zoom"
-    value={$rendering.scale}
-    on:change={(event) => {
-        $rendering.scale = event.detail;
-    }}
-    params={{
-        step: 0.01,
-    }}
-/>
+	<Field
+		key="zoom"
+		value={$rendering.scale}
+		on:change={(event) => {
+			$rendering.scale = event.detail;
+		}}
+		params={{
+			step: 0.01,
+		}}
+	/>
 {/if}
 {#if $rendering.resizing === SIZES.PRESET}
-<Field
-    key="preset"
-    value={$rendering.preset}
-    on:change={(event) => {
-        $rendering.preset = event.detail;
-    }}
-    params={{
-        options: presets,
-    }}
-/>
+	<Field
+		key="preset"
+		value={$rendering.preset}
+		on:change={(event) => {
+			$rendering.preset = event.detail;
+		}}
+		params={{
+			options: presets,
+		}}
+	/>
 {/if}
 
-{#if $rendering.resizing !== SIZES.PRESET }
-<Field
-    key="pixelRatio"
-    value={Number($rendering.pixelRatio)}
-    on:change={(event) => $rendering.pixelRatio = event.detail }
-    params={{
-        step: 0.1,
-    }}
-/>
+{#if $rendering.resizing !== SIZES.PRESET}
+	<Field
+		key="pixelRatio"
+		value={Number($rendering.pixelRatio)}
+		on:change={(event) => ($rendering.pixelRatio = event.detail)}
+		params={{
+			step: 0.1,
+		}}
+	/>
 {/if}
-{#if $sketchesCount > 1 && $monitors.length > 1 }
-<ParamsMultisampling />
+{#if $sketchesCount > 1 && $monitors.length > 1}
+	<ParamsMultisampling />
 {/if}

--- a/src/client/app/ui/SelectChevrons.svelte
+++ b/src/client/app/ui/SelectChevrons.svelte
@@ -1,25 +1,37 @@
 <script>
-export let width = 24;
-export let height = 24;
+	export let width = 24;
+	export let height = 24;
 </script>
 
 <div class="chevrons" style={`width: ${width}px;`}>
-	<svg class="chevron chevron-bottom" width={width} height={height} fill="none" viewBox="0 0 24 24">
-		<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.25 10.75L12 14.25L8.75 10.75"></path>
+	<svg
+		class="chevron chevron-bottom"
+		{width}
+		{height}
+		fill="none"
+		viewBox="0 0 24 24"
+	>
+		<path
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="1.5"
+			d="M15.25 10.75L12 14.25L8.75 10.75"
+		/>
 	</svg>
 </div>
 
 <style>
-.chevrons {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    align-items: center;
-    width: 15px;
+	.chevrons {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		width: 15px;
 
-    color: var(--color, currentColor);
-    pointer-events: none;
-}
+		color: inherit;
+		pointer-events: none;
+	}
 </style>

--- a/src/client/app/ui/fields/ButtonInput.svelte
+++ b/src/client/app/ui/fields/ButtonInput.svelte
@@ -1,56 +1,67 @@
 <script>
-export let value = null;
-export let label;
-export let disabled = false;
-export let showLabel = true;
-export let title = "";
-export let context = null;
-export let key = "";
-
+	export let value = null;
+	export let label;
+	export let disabled = false;
+	export let showLabel = true;
+	export let title = '';
+	export let context = null;
+	export let key = '';
 </script>
 
-<div class="button-container" class:disabled={disabled}>
-    <button class="button" {disabled} on:click {title} on:mouseenter on:mouseleave>
-        <span class="label" class:visually-hidden={!showLabel}>{label}</span>
-        <slot></slot>
-    </button>
+<div class="button-container" class:disabled>
+	<button
+		class="button"
+		{disabled}
+		on:click
+		{title}
+		on:mouseenter
+		on:mouseleave
+	>
+		<span class="label" class:visually-hidden={!showLabel}>{label}</span>
+		<slot />
+	</button>
 </div>
 
 <style>
-.button-container {
-    display: flex;
-    width: 100%;
-}
+	.button-container {
+		display: flex;
+		width: 100%;
+	}
 
-.button {
-    display: flex;
-    width: 100%;
-    min-width: var(--height-input);
-    height: var(--height-input);
-    justify-content: center;
-    align-items: center;
-    padding: 0 4px;
+	.button {
+		display: flex;
+		width: 100%;
+		min-width: var(--height-input);
+		height: var(--height-input);
+		justify-content: center;
+		align-items: center;
+		padding: 0 4px;
 
-    color: rgba(255, 255, 255, 0.5);
-    font-size: var(--font-size-input);
-    
-    border-radius: var(--border-radius-input);
-    background-color: var(--background-color, var(--color-background-input));
-    box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-border-input));
-}
+		color: var(--color-text-input);
+		font-size: var(--font-size-input);
 
-:global(.field.disabled) .button {
-    color: rgba(255, 255, 255, 0.2);
-}
+		border-radius: var(--border-radius-input);
+		background-color: var(
+			--background-color,
+			var(--color-background-input)
+		);
+		box-shadow: inset 0 0 0 1px
+			var(--box-shadow-color, var(--color-border-input));
+	}
 
-.button:hover {
-    color: var(--color-text);
+	.button:disabled {
+		color: var(--color-text-input-disabled);
+	}
 
-    box-shadow: inset 0 0 0 1px var(--box-shadow-color-active, var(--color-active));
-}
+	.button:hover {
+		color: var(--color-text);
 
-.button:active {
-    box-shadow: 0 0 0 2px var(--box-shadow-color-active, var(--color-active));
-}
+		box-shadow: inset 0 0 0 1px
+			var(--box-shadow-color-active, var(--color-active));
+	}
 
+	.button:active {
+		box-shadow: 0 0 0 2px
+			var(--box-shadow-color-active, var(--color-active));
+	}
 </style>

--- a/src/client/app/ui/fields/CheckboxInput.svelte
+++ b/src/client/app/ui/fields/CheckboxInput.svelte
@@ -1,72 +1,77 @@
 <script>
-import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from 'svelte';
 
-export let value;
-export let context = null;
-export let key = "";
+	export let value;
+	export let context = null;
+	export let key = '';
+	export let disabled = false;
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-function handleChange() {
-    dispatch("change", value);
-}
-
+	function handleChange() {
+		dispatch('change', value);
+	}
 </script>
 
 <div class="checkbox">
-    <input class="input" bind:checked={value} type="checkbox" on:change={handleChange} />
-    <div class="checked">
-    </div>
+	<input
+		class="input"
+		bind:checked={value}
+		type="checkbox"
+		on:change={handleChange}
+		disabled={disabled ? 'disabled' : null}
+	/>
+	<div class="checked" />
 </div>
 
 <style>
-.checkbox {
-    position: relative;
+	.checkbox {
+		position: relative;
 
-    width: var(--height-input);
-    height: var(--height-input);
-    margin-right: calc(var(--padding));
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
+		width: var(--height-input);
+		height: var(--height-input);
+		margin-right: calc(var(--padding));
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
 
-    border-radius: var(--border-radius-input);
-    background-color: var(--color-background-input);
-}
+		border-radius: var(--border-radius-input);
+		background-color: var(--color-background-input);
+	}
 
-.checkbox:hover {
-    box-shadow: inset 0 0 0 1px var(--color-active);
-}
+	.checkbox:hover {
+		box-shadow: inset 0 0 0 1px var(--color-active);
+	}
 
-.checkbox:focus-within {
-    box-shadow: 0 0 0 2px var(--color-active);
-}
+	.checkbox:focus-within {
+		box-shadow: 0 0 0 2px var(--color-active);
+	}
 
-.input {
-    width: 100%;
-    height: 100%;
-    border: none;
-    border-radius: var(--border-radius-input);
-    background-color: transparent;
-}
+	.input {
+		width: 100%;
+		height: 100%;
+		border: none;
+		border-radius: var(--border-radius-input);
+		background-color: transparent;
+	}
 
-/* .input:checked {
-    background-color: var(--color-active);
-} */
+	.checked {
+		position: absolute;
+		left: 3px;
+		top: 3px;
+		bottom: 3px;
+		right: 3px;
 
-.checked {
-    position: absolute;
-    left: 3px;
-    top: 3px;
-    bottom: 3px;
-    right: 3px;
+		border-radius: calc(var(--border-radius-input) * 0.5);
+		background-color: var(--color-active);
 
-    border-radius: calc(var(--border-radius-input) * 0.5);
-    background-color: var(--color-active);
+		opacity: 0;
+		pointer-events: none;
+	}
 
-    opacity: 0;
-    pointer-events: none;
-}
+	.input:checked + .checked {
+		opacity: 1;
+	}
 
-.input:checked + .checked {
-    opacity: 1;
-}
+	.input:checked:disabled + .checked {
+		opacity: 0.4;
+	}
 </style>

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -1,245 +1,301 @@
 <script>
-import { createEventDispatcher } from "svelte";
-import * as color from "../../utils/color.utils.js";
-import TextInput from "./TextInput.svelte";
-import Field from "../Field.svelte";
+	import { createEventDispatcher } from 'svelte';
+	import * as color from '../../utils/color.utils.js';
+	import TextInput from './TextInput.svelte';
+	import Field from '../Field.svelte';
 
-export let value;
-export let context = null;
-export let key = "";
+	export let value;
+	export let context = null;
+	export let key = '';
+	export let disabled = false;
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-$: format = color.getColorFormat(value);
-$: hexValue = color.toHex(value, format);
-$: textValue = color.toString(value, format);
-$: alpha = 1;
-$: hasAlpha = [
-    color.FORMATS.RGBA_STRING,
-    color.FORMATS.VEC4_STRING,
-    color.FORMATS.VEC4_ARRAY,
-    color.FORMATS.RGBA_OBJECT,
-    color.FORMATS.HSLA_STRING
-].includes(format);
-$: {
-    if (hasAlpha) {
-        const [r, g, b, a = 1] = color.toComponents(value);
-        alpha = a;
-    } else {
-        alpha = 1;
-    }
-}
+	$: format = color.getColorFormat(value);
+	$: hexValue = color.toHex(value, format);
+	$: textValue = color.toString(value, format);
+	$: alpha = 1;
+	$: hasAlpha = [
+		color.FORMATS.RGBA_STRING,
+		color.FORMATS.VEC4_STRING,
+		color.FORMATS.VEC4_ARRAY,
+		color.FORMATS.RGBA_OBJECT,
+		color.FORMATS.HSLA_STRING,
+	].includes(format);
+	$: {
+		if (hasAlpha) {
+			const [r, g, b, a = 1] = color.toComponents(value);
+			alpha = a;
+		} else {
+			alpha = 1;
+		}
+	}
 
-function dispatchChange() {
-    const [r, g, b] = color.hexToComponents(hexValue);
+	function dispatchChange() {
+		const [r, g, b] = color.hexToComponents(hexValue);
 
-    // support THREE.Color
-    switch (format) {
-        case color.FORMATS.VEC3_ARRAY:
-            value[0] = r;
-            value[1] = g;
-            value[2] = b;
-            dispatch('change', value);
-            break;
-        case color.FORMATS.VEC4_ARRAY:
-            value[0] = r;
-            value[1] = g;
-            value[2] = b;
-            value[3] = alpha;
-            dispatch('change', value);
-            break;
-        case color.FORMATS.THREE:
-        case color.FORMATS.RGB_OBJECT:
-            value.r = r;
-            value.g = g;
-            value.b = b;
+		// support THREE.Color
+		switch (format) {
+			case color.FORMATS.VEC3_ARRAY:
+				value[0] = r;
+				value[1] = g;
+				value[2] = b;
+				dispatch('change', value);
+				break;
+			case color.FORMATS.VEC4_ARRAY:
+				value[0] = r;
+				value[1] = g;
+				value[2] = b;
+				value[3] = alpha;
+				dispatch('change', value);
+				break;
+			case color.FORMATS.THREE:
+			case color.FORMATS.RGB_OBJECT:
+				value.r = r;
+				value.g = g;
+				value.b = b;
 
-            dispatch('change', value);
-            break;
-        case color.FORMATS.RGBA_OBJECT:
-            value.r = r;
-            value.g = g;
-            value.b = b;
-            value.a = alpha;
+				dispatch('change', value);
+				break;
+			case color.FORMATS.RGBA_OBJECT:
+				value.r = r;
+				value.g = g;
+				value.b = b;
+				value.a = alpha;
 
-            dispatch('change', value);
-            break;
-        default:
-            dispatch('change', textValue);
-    }
-}
+				dispatch('change', value);
+				break;
+			default:
+				dispatch('change', textValue);
+		}
+	}
 
-function handleBlur() {
-    dispatchChange();
-}
+	function handleBlur() {
+		dispatchChange();
+	}
 
-function onChangeText(event) {
-    const newColor = event.detail;
+	function onChangeText(event) {
+		const newColor = event.detail;
 
-    if (color.isColor(newColor)) {
-        textValue = newColor;
-    } else {
-        // newColor is not a color, reset value
-        textValue = color.toString(value, format);
-    }
+		if (color.isColor(newColor)) {
+			textValue = newColor;
+		} else {
+			// newColor is not a color, reset value
+			textValue = color.toString(value, format);
+		}
 
-    hexValue = color.toHex(textValue);
-    dispatchChange();
-}
+		hexValue = color.toHex(textValue);
+		dispatchChange();
+	}
 
-function onChangeAlpha(event) {
-    alpha = event.detail;
+	function onChangeAlpha(event) {
+		alpha = event.detail;
 
-    const [r, g, b] = color.hexToComponents(hexValue);
+		const [r, g, b] = color.hexToComponents(hexValue);
 
-    switch(format) {
-        case color.FORMATS.RGBA_STRING:
-        case color.FORMATS.RGBA_OBJECT:
-            textValue = color.componentsToRGBAString([r, g, b, alpha]);
-            break;
-        case color.FORMATS.VEC4_STRING:
-            textValue = color.componentsToVec4String([r, g, b, alpha]);
-            break;
-        case color.FORMATS.HSLA_STRING:
-            const [h, s, l] = color.hslToHSLComponents(textValue);
-            textValue = color.hslaToHSLAString([h, s, l, alpha]);
-            break;
-    }
+		switch (format) {
+			case color.FORMATS.RGBA_STRING:
+			case color.FORMATS.RGBA_OBJECT:
+				textValue = color.componentsToRGBAString([r, g, b, alpha]);
+				break;
+			case color.FORMATS.VEC4_STRING:
+				textValue = color.componentsToVec4String([r, g, b, alpha]);
+				break;
+			case color.FORMATS.HSLA_STRING:
+				const [h, s, l] = color.hslToHSLComponents(textValue);
+				textValue = color.hslaToHSLAString([h, s, l, alpha]);
+				break;
+		}
 
-    dispatchChange();
-}
+		dispatchChange();
+	}
 
-function onInput(event) {
-    hexValue = event.currentTarget.value;
+	function onInput(event) {
+		hexValue = event.currentTarget.value;
 
-    const [r, g, b] = color.hexToComponents(hexValue);
+		const [r, g, b] = color.hexToComponents(hexValue);
 
-    switch(format) {
-        case color.FORMATS.RGBA_STRING:
-        case color.FORMATS.RGBA_OBJECT:
-            textValue = color.toRGBAString({ r, g, b, a: alpha });
-            break;
-        case color.FORMATS.VEC3_STRING:
-            textValue = color.componentsToVec3String([r, g, b]);
-            break;
-        case color.FORMATS.VEC4_STRING:
-            textValue = color.componentsToVec4String([r, g, b, alpha]);
-            break;
-        case color.FORMATS.RGB_STRING:
-        case color.FORMATS.RGB_OBJECT:
-            textValue = color.toRGBString(hexValue);
-            break;
-        case color.FORMATS.HSL_STRING:
-            textValue = color.componentsToHSLString([r, g, b]);
-            break;
-        case color.FORMATS.HSLA_STRING:
-            textValue = color.componentsToHSLAString([r, g, b, alpha]);
-            break;
-        default:
-            textValue = color.toString(hexValue);
-            break;
-    }
+		switch (format) {
+			case color.FORMATS.RGBA_STRING:
+			case color.FORMATS.RGBA_OBJECT:
+				textValue = color.toRGBAString({ r, g, b, a: alpha });
+				break;
+			case color.FORMATS.VEC3_STRING:
+				textValue = color.componentsToVec3String([r, g, b]);
+				break;
+			case color.FORMATS.VEC4_STRING:
+				textValue = color.componentsToVec4String([r, g, b, alpha]);
+				break;
+			case color.FORMATS.RGB_STRING:
+			case color.FORMATS.RGB_OBJECT:
+				textValue = color.toRGBString(hexValue);
+				break;
+			case color.FORMATS.HSL_STRING:
+				textValue = color.componentsToHSLString([r, g, b]);
+				break;
+			case color.FORMATS.HSLA_STRING:
+				textValue = color.componentsToHSLAString([r, g, b, alpha]);
+				break;
+			default:
+				textValue = color.toString(hexValue);
+				break;
+		}
 
-    dispatchChange();
-}
-
+		dispatchChange();
+	}
 </script>
 
-<div class="color-input">
-    <div class="layout">
-        <div class="mirror" style="--currentColor: {hexValue}; --opacity: {alpha}">
-            {#if hasAlpha }
-            <svg width="calc(100% - 2px)" height="calc(100% - 2px)" class="alpha-svg">
-                <pattern id="checker" x="0" y="0" width="7.2" height="7.2" patternUnits="userSpaceOnUse">
-                    <rect fill="white" x="0" width="3.6" height="3.6" y="0"></rect>
-                    <rect fill="grey" x="3.6" width="3.6" height="3.6" y="0"></rect>
-                    <rect fill="white" x="3.6" width="3.6" height="3.6" y="3.6"></rect>
-                    <rect fill="grey" x="0" width="3.6" height="3.6" y="3.6"></rect>
-                </pattern>
-                <!-- The canvas with our applied pattern -->
-                <rect x="0" y="0" width="100%" height="100%" fill="url(#checker)"></rect>
-            </svg>
-            {/if}
-            <!-- svelte-ignore -->
-            <input class="input" type="color" bind:value={hexValue} on:blur={handleBlur} on:input={onInput} />
-        </div>
-        <TextInput {context} {key} bind:value={textValue} on:change={onChangeText} />
-    </div>
-    {#if hasAlpha }
-        <Field
-            key={`${key}.alpha`}
-            value={alpha}
-            params={{label: "alpha", min: 0, max: 1, step: 0.01}}
-            {context}
-            on:change={onChangeAlpha}
-        />
-    {/if }
+<div class="color-input" class:disabled>
+	<div class="layout">
+		<div
+			class="mirror"
+			style="--currentColor: {hexValue}; --opacity: {alpha}"
+		>
+			{#if hasAlpha}
+				<svg
+					width="calc(100% - 2px)"
+					height="calc(100% - 2px)"
+					class="alpha-svg"
+				>
+					<pattern
+						id="checker"
+						x="0"
+						y="0"
+						width="7.2"
+						height="7.2"
+						patternUnits="userSpaceOnUse"
+					>
+						<rect
+							fill="white"
+							x="0"
+							width="3.6"
+							height="3.6"
+							y="0"
+						/>
+						<rect
+							fill="grey"
+							x="3.6"
+							width="3.6"
+							height="3.6"
+							y="0"
+						/>
+						<rect
+							fill="white"
+							x="3.6"
+							width="3.6"
+							height="3.6"
+							y="3.6"
+						/>
+						<rect
+							fill="grey"
+							x="0"
+							width="3.6"
+							height="3.6"
+							y="3.6"
+						/>
+					</pattern>
+					<!-- The canvas with our applied pattern -->
+					<rect
+						x="0"
+						y="0"
+						width="100%"
+						height="100%"
+						fill="url(#checker)"
+					/>
+				</svg>
+			{/if}
+			<!-- svelte-ignore -->
+			<input
+				class="input"
+				type="color"
+				disabled={disabled ? 'disabled' : null}
+				bind:value={hexValue}
+				on:blur={handleBlur}
+				on:input={onInput}
+			/>
+		</div>
+		<TextInput
+			{context}
+			{key}
+			{disabled}
+			bind:value={textValue}
+			on:change={onChangeText}
+		/>
+	</div>
+	{#if hasAlpha}
+		<Field
+			key={`${key}.alpha`}
+			value={alpha}
+			params={{ label: 'alpha', min: 0, max: 1, step: 0.01 }}
+			{context}
+			on:change={onChangeAlpha}
+		/>
+	{/if}
 </div>
 
 <style>
-.color-input {
-    position: relative;
-    width: 100%;
-}
+	.color-input {
+		position: relative;
+		width: 100%;
+	}
 
-.layout {
-    display: grid;
-    column-gap: var(--column-gap);
-    grid-template-columns: 0.35fr 0.65fr;
-    align-items: center;
-}
+	.layout {
+		display: grid;
+		column-gap: var(--column-gap);
+		grid-template-columns: 0.35fr 0.65fr;
+		align-items: center;
+	}
 
-.alpha-svg {
-    position: absolute;
-    top: 1px;
-    left: 1px;
-    right: 1px;
-    bottom: 1px;
+	.alpha-svg {
+		position: absolute;
+		top: 1px;
+		left: 1px;
+		right: 1px;
+		bottom: 1px;
 
-    border-radius: calc(var(--border-radius-input) * 0.5);
-}
+		border-radius: calc(var(--border-radius-input) * 0.5);
+	}
 
-.mirror {
-    position: relative;
-    
-    height: var(--height-input);
+	.mirror {
+		position: relative;
 
-    border-radius: var(--border-radius-input);
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
-}
+		height: var(--height-input);
 
-.mirror:after {
-    --gap: 1px;
+		border-radius: var(--border-radius-input);
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
+	}
 
-    content: '';
-    position: absolute;
-    z-index: 1;
-    top: var(--gap);
-    left: var(--gap);
-    right: var(--gap);
-    bottom: var(--gap);
+	.mirror:after {
+		--gap: 1px;
 
-    background-color: var(--currentColor);
-    border-radius: calc(var(--border-radius-input) * 0.5);
-    opacity: var(--opacity, 1);
-    pointer-events: none;
-}
+		content: '';
+		position: absolute;
+		z-index: 1;
+		top: var(--gap);
+		left: var(--gap);
+		right: var(--gap);
+		bottom: var(--gap);
 
-.mirror:hover {
-    box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-active));
-}
+		background-color: var(--currentColor);
+		border-radius: calc(var(--border-radius-input) * 0.5);
+		opacity: var(--opacity, 1);
+		pointer-events: none;
+	}
 
-.mirror:focus-within {
-    box-shadow: 0 0 0 2px var(--box-shadow-color, var(--color-active));
-}
+	.mirror:hover {
+		box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-active));
+	}
 
-.input {
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    cursor: pointer;
-    background: transparent;
-    border: none;
-}
+	.mirror:focus-within {
+		box-shadow: 0 0 0 2px var(--box-shadow-color, var(--color-active));
+	}
 
+	.input {
+		width: 100%;
+		height: 100%;
+		opacity: 0;
+		cursor: pointer;
+		background: transparent;
+		border: none;
+	}
 </style>

--- a/src/client/app/ui/fields/Input.svelte
+++ b/src/client/app/ui/fields/Input.svelte
@@ -1,126 +1,115 @@
 <script>
-import { createEventDispatcher } from "svelte";
+	import { createEventDispatcher } from 'svelte';
 
+	export let label = null;
+	export let value;
+	export let disabled = false;
+	export let context = null;
+	export let key = '';
 
-export let label = null;
-export let value;
-export let disabled = false;
-export let context = null;
-export let key = "";
+	let node;
 
-let node;
+	const dispatch = createEventDispatcher();
 
-const dispatch = createEventDispatcher();
+	function onKeyPress(event) {
+		if (event.key === 'Enter') {
+			node.blur();
+		}
+	}
 
-function onKeyPress(event) {
-    if (event.key === 'Enter') {
-        node.blur();
-    }
-}
+	function handleInput(event) {
+		dispatch('input', event.currentTarget.value);
+	}
 
-function handleInput(event) {
-    dispatch('input', event.currentTarget.value);
-}
-
-function handleChange(event) {
-    dispatch('change', event.currentTarget.value);
-}
-
+	function handleChange(event) {
+		dispatch('change', event.currentTarget.value);
+	}
 </script>
 
-<div class="input-container" class:disabled={disabled}>
-    {#if label }
-        <span class="label">{label}</span>
-    {/if}
-    <input
-        class="input"
-        bind:this={node}
-        bind:value={value}
-        on:change={handleChange}
-        on:input={handleInput}
-        on:keypress={onKeyPress}
-        on:keydown
-        on:focus
-        on:blur
-        {disabled}
-        autocomplete="off"
-        spellcheck="false"
-    />
+<div class="input-container" class:disabled>
+	{#if label}
+		<span class="label">{label}</span>
+	{/if}
+	<input
+		class="input"
+		bind:this={node}
+		bind:value
+		on:change={handleChange}
+		on:input={handleInput}
+		on:keypress={onKeyPress}
+		on:keydown
+		on:focus
+		on:blur
+		disabled={disabled ? 'disabled' : null}
+		autocomplete="off"
+		spellcheck="false"
+	/>
 </div>
 
 <style>
-.input-container {
-    position: relative;
+	.input-container {
+		position: relative;
 
-    display: flex;
-    height: var(--height-input);
-    margin: 2px 0;
+		display: flex;
+		height: var(--height-input);
+		margin: 2px 0;
 
-    border-radius: var(--border-radius-input);
-    background-color: var(--color-background-input);
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
-}
+		border-radius: var(--border-radius-input);
+		background-color: var(--color-background-input);
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
+	}
 
-.input-container:not(.disabled):hover {
-    box-shadow: inset 0 0 0 1px var(--color-active);
-}
+	.input-container:not(.disabled):hover {
+		box-shadow: inset 0 0 0 1px var(--color-active);
+	}
 
-.input-container:not(.disabled):focus-within {
-    box-shadow: 0 0 0 2px var(--color-active);
-}
+	.input-container:not(.disabled):focus-within {
+		box-shadow: 0 0 0 2px var(--color-active);
+	}
 
-.label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
+	.label {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
 
-    display: flex;
-    align-items: center;
-    padding: var(--padding);
+		display: flex;
+		align-items: center;
+		padding: var(--padding);
 
-    color: var(--color-text);
-    font-size: var(--font-size-input);
-    font-weight: 600;
-    pointer-events: none;
-    opacity: 0.35;
-}
+		color: var(--color-text);
+		font-size: var(--font-size-input);
+		font-weight: 600;
+		pointer-events: none;
+		opacity: 0.35;
+	}
 
-.input-container.disabled .label {
-    opacity: 0.15;
-}
+	.input-container.disabled .label {
+		opacity: 0.1;
+	}
 
-.input {
-    width: 100%;
-    height: 100%;
-    padding: 0 var(--padding);
+	.input {
+		width: 100%;
+		height: 100%;
+		padding: 0 var(--padding);
 
-    color: rgba(255, 255, 255, 0.5);
-    font-size: var(--font-size-input);
-    text-align: right;
+		color: var(--color-text-input);
+		font-size: var(--font-size-input);
+		text-align: right;
 
-    background: transparent;
-    outline: 0;
-}
+		background: transparent;
+		outline: 0;
+	}
 
-.input:disabled {
-    opacity: 0.4;
-}
+	.input:disabled {
+		color: var(--color-text-input-disabled);
+	}
 
-:global(.field.disabled) .input {
-    opacity: 0.4;
-}
+	.input:focus {
+		color: var(--color-text);
+	}
 
-:global(.field__section:hover .container .input) {
-    color: var(--color-text);
-}
-
-input:focus {
-    color: var(--color-text);
-}
-
-/* .input:focus {
+	/* .input:focus {
     border: var(--borderWidth) solid var(--color-active);
 } */
-
 </style>

--- a/src/client/app/ui/fields/ListInput.svelte
+++ b/src/client/app/ui/fields/ListInput.svelte
@@ -1,108 +1,108 @@
 <script>
-import { afterUpdate } from "svelte";
+	import { afterUpdate } from 'svelte';
 
-export let disabled;
-export let value = null;
-export let context = null;
-export let key = "";
+	export let disabled;
+	export let value = null;
+	export let context = null;
+	export let key = '';
 
-let container;
+	let container;
 
-afterUpdate(() => {
-    container.scrollTo(0, container.scrollHeight);
-});
-
+	afterUpdate(() => {
+		container.scrollTo(0, container.scrollHeight);
+	});
 </script>
 
-<div class="list {disabled ? "disabled" : ""}">
-    <div class="container" bind:this={container}>
-        <ul class="ul">
-            {#each value as item, index}
-                <li class="item">
-                    {#if disabled }
-                        <span class="label">{item}</span>
-                    {:else}
-                        <button class="label">{item}</button>
-                    {/if}
-                </li>
-            {/each}
-        </ul>
-    </div>
+<div class="list" class:disabled>
+	<div class="container" bind:this={container}>
+		<ul class="ul">
+			{#each value as item, index}
+				<li class="item">
+					{#if disabled}
+						<span class="label">{item}</span>
+					{:else}
+						<button class="label">{item}</button>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
 </div>
 
 <style>
-.list {
-    width: 100%;
+	.list {
+		width: 100%;
 
-    pointer-events: auto;
-}
+		pointer-events: auto;
+	}
 
-.container {
-    margin-right: var(--padding);
-    padding: 1px 0;
-    height: 80px;
+	.container {
+		margin-right: var(--padding);
+		padding: 1px 0;
+		height: 80px;
 
-    background-color: #1d1d1e;
-    border-radius: var(--border-radius-input);
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
-    overflow-y: scroll;
-}
+		background-color: #1d1d1e;
+		border-radius: var(--border-radius-input);
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
+		overflow-y: scroll;
+	}
 
-.ul {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    padding: 2px 0;
-    
-}
+	.ul {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		padding: 2px 0;
+	}
 
-.container::-webkit-scrollbar {
-    width: 5px;               /* width of the entire scrollbar */
-}
+	.container::-webkit-scrollbar {
+		width: 5px; /* width of the entire scrollbar */
+	}
 
-.container::-webkit-scrollbar-track {
-    background-color: var(--color-lightblack);        /* color of the tracking area */
-}
+	.container::-webkit-scrollbar-track {
+		background-color: var(
+			--color-lightblack
+		); /* color of the tracking area */
+	}
 
-.container::-webkit-scrollbar-thumb {
-    background-color: var(--color-active);    /* color of the scroll thumb */
-    border-radius: 20px;       /* roundness of the scroll thumb */
-}
+	.container::-webkit-scrollbar-thumb {
+		background-color: var(--color-active); /* color of the scroll thumb */
+		border-radius: 20px; /* roundness of the scroll thumb */
+	}
 
-.item {
-    display: flex;
-    width: 100%;
+	.item {
+		display: flex;
+		width: 100%;
 
-    margin: 0;
-    padding: 0 3px;
-    color: var(--color-text);
-    font-size: 10px;
+		margin: 0;
+		padding: 0 3px;
+		color: var(--color-text);
+		font-size: 10px;
 
-    opacity: 0.35;
-    user-select: none;
-}
+		opacity: 0.35;
+		user-select: none;
+	}
 
-.label {
-    width: 100%;
-    padding: 1px var(--padding);
-    background-color: transparent;
-    text-align: left;
-}
+	.label {
+		width: 100%;
+		padding: 1px var(--padding);
+		background-color: transparent;
+		text-align: left;
+	}
 
-.list:not(.disabled) .label:hover {
-    box-shadow: inset 0 0 0 1px var(--color-active);
-}
+	.list:not(.disabled) .label:hover {
+		box-shadow: inset 0 0 0 1px var(--color-active);
+	}
 
-.list:not(.disabled) .label:active {
-    box-shadow: 0 0 0 2px var(--color-active);
-}
+	.list:not(.disabled) .label:active {
+		box-shadow: 0 0 0 2px var(--color-active);
+	}
 
-.item:hover {
-    /* background-color: #0E0E0E; */
-    opacity: 1;
-}
+	.item:hover {
+		/* background-color: #0E0E0E; */
+		opacity: 1;
+	}
 
-/* :global(.field:hover) .list:not(.disabled) .item {
+	/* :global(.field:hover) .list:not(.disabled) .item {
     opacity: 1;
 } */
 </style>

--- a/src/client/app/ui/fields/NumberInput.svelte
+++ b/src/client/app/ui/fields/NumberInput.svelte
@@ -1,123 +1,128 @@
 <script>
-import { createEventDispatcher } from "svelte";
-import FieldInputRow from "./FieldInputRow.svelte";
-import Input from "./Input.svelte";
-import ProgressInput from "./ProgressInput.svelte";
-import Keyboard from "../../inputs/Keyboard.js";
-import { clamp } from "../../utils/math.utils.js";
+	import { createEventDispatcher } from 'svelte';
+	import FieldInputRow from './FieldInputRow.svelte';
+	import Input from './Input.svelte';
+	import ProgressInput from './ProgressInput.svelte';
+	import Keyboard from '../../inputs/Keyboard.js';
+	import { clamp } from '../../utils/math.utils.js';
 
-function round(value, step) {
-    return Math.round(value * (1 / step)) / (1 / step);
-}
+	function round(value, step) {
+		return Math.round(value * (1 / step)) / (1 / step);
+	}
 
-export let value = null;
-export let label = "";
-export let step = 1;
-export let suffix = "";
-export let min = -Infinity;
-export let max = Infinity;
-export let disabled = false;
-export let context = null;
-export let key = "";
+	export let value = null;
+	export let label = '';
+	export let step = 1;
+	export let suffix = '';
+	export let min = -Infinity;
+	export let max = Infinity;
+	export let disabled = false;
+	export let context = null;
+	export let key = '';
 
-$: isFocused = false;
-const dispatch = createEventDispatcher();
+	$: isFocused = false;
+	const dispatch = createEventDispatcher();
 
-function sanitize(v, suffix) {
-    return (suffix && suffix !== "") ? Number(v.split(suffix)[0]) : Number(v);
-}
+	function sanitize(v, suffix) {
+		return suffix && suffix !== '' ? Number(v.split(suffix)[0]) : Number(v);
+	}
 
-function composeValue(v, isFocused, suffix = "") {
-    const clampedValue = clamp(v, isFinite(min) ? min : -Infinity, isFinite(max) ? max : Infinity);
-    const roundedValue = typeof step === "number" ? round(clampedValue, step) : v;
+	function composeValue(v, isFocused, suffix = '') {
+		const clampedValue = clamp(
+			v,
+			isFinite(min) ? min : -Infinity,
+			isFinite(max) ? max : Infinity,
+		);
+		const roundedValue =
+			typeof step === 'number' ? round(clampedValue, step) : v;
 
-    return isFocused ? `${roundedValue}` : `${roundedValue}${suffix}`;
-}
+		return isFocused ? `${roundedValue}` : `${roundedValue}${suffix}`;
+	}
 
-$: currentValue = value;
-$: composedValue = composeValue(currentValue, isFocused, suffix);
+	$: currentValue = value;
+	$: composedValue = composeValue(currentValue, isFocused, suffix);
 
-function onFocus() {
-    isFocused = true;
-}
+	function onFocus() {
+		isFocused = true;
+	}
 
-function onBlur(event) {
-    isFocused = false;
+	function onBlur(event) {
+		isFocused = false;
 
-    let newValue = event.currentTarget.value;
-    let isNotValid = isNaN(Number(event.currentTarget.value));
+		let newValue = event.currentTarget.value;
+		let isNotValid = isNaN(Number(event.currentTarget.value));
 
-    if (isNotValid) {
-        newValue = `${value}`;
-    }
+		if (isNotValid) {
+			newValue = `${value}`;
+		}
 
-    currentValue = sanitize(newValue, suffix);
+		currentValue = sanitize(newValue, suffix);
 
-    dispatch('change', currentValue);
-}
+		dispatch('change', currentValue);
+	}
 
-function onKeyDown(event) {
-    if ([38, 40].includes(event.keyCode)) {
-        event.preventDefault();
+	function onKeyDown(event) {
+		if ([38, 40].includes(event.keyCode)) {
+			event.preventDefault();
 
-        const diff = Keyboard.getStepFromEvent(event) * step;
-        const direction = event.keyCode === 38 ? 1 : -1;
-        const newValue = sanitize(composedValue, suffix) + direction * (diff);
+			const diff = Keyboard.getStepFromEvent(event) * step;
+			const direction = event.keyCode === 38 ? 1 : -1;
+			const newValue = sanitize(composedValue, suffix) + direction * diff;
 
-        currentValue = newValue;
-        dispatch('change', currentValue);
-    }
-}
+			currentValue = newValue;
+			dispatch('change', currentValue);
+		}
+	}
 
-$: hasProgress = isFinite(min) && isFinite(max);
+	$: hasProgress = isFinite(min) && isFinite(max);
 
-function handleChangeProgress(event) {
-    currentValue = event.detail;
-    dispatch('change', event.detail);
-}
-
+	function handleChangeProgress(event) {
+		currentValue = event.detail;
+		dispatch('change', event.detail);
+	}
 </script>
 
-<div class="number-input {hasProgress ? "number-input--with-progress": ""}">
-    {#if hasProgress}
-        <FieldInputRow --grid-template-columns="1fr 0.5fr">
-            <ProgressInput
-                step={step}
-                value={currentValue}
-                min={min}
-                max={max}
-                {context}
-                {key}
-                on:change={handleChangeProgress}
-            />
-            <Input 
-                {label}
-                {disabled}
-                {context}
-                {key}
-                on:keydown={onKeyDown}
-                on:focus={onFocus}
-                on:blur={onBlur}
-                bind:value={composedValue}
-            />
-        </FieldInputRow>
-    {:else}
-        <Input 
-            {label}
-            {disabled}
-            {context}
-            {key}
-            on:keydown={onKeyDown}
-            on:focus={onFocus}
-            on:blur={onBlur}
-            bind:value={composedValue}
-        />
-    {/if}
+<div class="number-input {hasProgress ? 'number-input--with-progress' : ''}">
+	{#if hasProgress}
+		<FieldInputRow --grid-template-columns="1fr 0.5fr">
+			<ProgressInput
+				{step}
+				value={currentValue}
+				{min}
+				{max}
+				{context}
+				{disabled}
+				{key}
+				on:change={handleChangeProgress}
+			/>
+			<Input
+				{label}
+				{disabled}
+				{context}
+				{key}
+				on:keydown={onKeyDown}
+				on:focus={onFocus}
+				on:blur={onBlur}
+				bind:value={composedValue}
+			/>
+		</FieldInputRow>
+	{:else}
+		<Input
+			{label}
+			{disabled}
+			{context}
+			{key}
+			on:keydown={onKeyDown}
+			on:focus={onFocus}
+			on:blur={onBlur}
+			bind:value={composedValue}
+		/>
+	{/if}
 </div>
 
 <style>
-.number-input {
-    position: relative;
-    width: 100%;
-}
+	.number-input {
+		position: relative;
+		width: 100%;
+	}
 </style>

--- a/src/client/app/ui/fields/ProgressInput.svelte
+++ b/src/client/app/ui/fields/ProgressInput.svelte
@@ -1,94 +1,101 @@
 <script>
-import { createEventDispatcher } from "svelte";
-import { map, clamp } from "../../utils/math.utils.js";
+	import { createEventDispatcher } from 'svelte';
+	import { map, clamp } from '../../utils/math.utils.js';
 
-export let value;
-export let min;
-export let max;
-export let step;
-export let context = null;
-export let key = "";
+	export let value;
+	export let min;
+	export let max;
+	export let step;
+	export let context = null;
+	export let key = '';
+	export let disabled = false;
 
-let node;
-let rect;
+	let node;
+	let rect;
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-let isDragging = false;
+	let isDragging = false;
 
-// handlers
-function handleMouseDown(event) {
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+	// handlers
+	function handleMouseDown(event) {
+		document.addEventListener('mousemove', handleMouseMove);
+		document.addEventListener('mouseup', handleMouseUp);
 
-    rect = node.getBoundingClientRect();
+		rect = node.getBoundingClientRect();
 
-    isDragging = true;
+		isDragging = true;
 
-    onDrag(event);
-}
+		onDrag(event);
+	}
 
-function handleMouseMove(event) {
-    onDrag(event);
-}
+	function handleMouseMove(event) {
+		onDrag(event);
+	}
 
-function onDrag(event) {
-    let v = clamp(map(event.clientX, rect.left, rect.right, min, max), min, max);
-    v = Math.floor(v * (1 / step)) / (1 / step);
+	function onDrag(event) {
+		let v = clamp(
+			map(event.clientX, rect.left, rect.right, min, max),
+			min,
+			max,
+		);
+		v = Math.floor(v * (1 / step)) / (1 / step);
 
-    if (v !== value) {
-        dispatch("change", v);
-    }
-}
+		if (v !== value) {
+			dispatch('change', v);
+		}
+	}
 
-function handleMouseUp() {
-    document.removeEventListener('mousemove', handleMouseMove);
-    document.removeEventListener('mouseup', handleMouseUp);
+	function handleMouseUp() {
+		document.removeEventListener('mousemove', handleMouseMove);
+		document.removeEventListener('mouseup', handleMouseUp);
 
-    isDragging = false;
-}
+		isDragging = false;
+	}
 
-$: scaleX = clamp(map(value, min, max, 0, 1), 0, 1);
-
+	$: scaleX = clamp(map(value, min, max, 0, 1), 0, 1);
+	$: opacity = scaleX > 0 ? 1 * (disabled ? 0.4 : 1) : 0;
 </script>
 
-<div class="progress {isDragging ? "dragging": ""} " bind:this={node} on:mousedown={handleMouseDown}>
-    <div class="fill" style="opacity: {scaleX > 0 ? 1 : 0}; transform: scaleX({scaleX})"></div>
+<div
+	class="progress {isDragging ? 'dragging' : ''} "
+	bind:this={node}
+	on:mousedown={handleMouseDown}
+>
+	<div class="fill" style="opacity: {opacity}; transform: scaleX({scaleX})" />
 </div>
 
 <style>
-.progress {
-    position: relative;
-    
-    height: var(--height-input);
-    border-radius: var(--border-radius-input);
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
+	.progress {
+		position: relative;
 
-    background: var(--color-background-input);
-    cursor: ew-resize;
-}
+		height: var(--height-input);
+		border-radius: var(--border-radius-input);
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
 
-.progress:hover {
-    box-shadow: inset 0 0 0 1px var(--color-active);
-}
+		background: var(--color-background-input);
+		cursor: ew-resize;
+	}
 
-.progress.dragging {
-    box-shadow: 0 0 0 2px var(--color-active);
-}
+	.progress:hover {
+		box-shadow: inset 0 0 0 1px var(--color-active);
+	}
 
+	.progress.dragging {
+		box-shadow: 0 0 0 2px var(--color-active);
+	}
 
-.fill {
-    position: absolute;
-    left: 3px;
-    top: 3px;
-    bottom: 3px;
-    right: 3px;
+	.fill {
+		position: absolute;
+		left: 3px;
+		top: 3px;
+		bottom: 3px;
+		right: 3px;
 
-    background: grey;
-    transform-origin: 0 50%;
-    border-radius: calc(var(--border-radius-input) * 0.5);
+		background: grey;
+		transform-origin: 0 50%;
+		border-radius: calc(var(--border-radius-input) * 0.5);
 
-    background-color: var(--color-active);
-}
-
+		background-color: var(--color-active);
+	}
 </style>

--- a/src/client/app/ui/fields/Select.svelte
+++ b/src/client/app/ui/fields/Select.svelte
@@ -1,146 +1,159 @@
 <script>
-import { createEventDispatcher } from "svelte";
-import SelectChevrons from "../SelectChevrons.svelte";
+	import { createEventDispatcher } from 'svelte';
+	import SelectChevrons from '../SelectChevrons.svelte';
 
-export let options = [];
-export let name = "";
-export let value;
-export let disabled = false;
-export let title = "";
-export let context = null;
-export let key = "";
+	export let options = [];
+	export let name = '';
+	export let value;
+	export let disabled = false;
+	export let title = '';
+	export let context = null;
+	export let key = '';
 
-let node;
-let sanitizedValue, sanitizedOptions = [];
+	let node;
+	let sanitizedValue,
+		sanitizedOptions = [];
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-function toStringifiedValue(option, optionType = typeof option) {
-    if (option === null) {
-        return `null`;
-    } else if (option === undefined) {
-        return `undefined`;
-    } else if (optionType === "object") {
-        return toStringifiedValue(option.value);
-    } else if (optionType === "function") {
-        return option.name;
-    }
-    
-    return option.toString();
-}
+	function toStringifiedValue(option, optionType = typeof option) {
+		if (option === null) {
+			return `null`;
+		} else if (option === undefined) {
+			return `undefined`;
+		} else if (optionType === 'object') {
+			return toStringifiedValue(option.value);
+		} else if (optionType === 'function') {
+			return option.name;
+		}
 
-$: {
-    sanitizedOptions = [];
-    
-    for (let i = 0; i < options.length; i++) {
-        let option = options[i];
-        let optionType = typeof option;
-        let disabled = (optionType === "object" && typeof option.disabled === "boolean") ? option.disabled : false;
-        let _value = optionType === "object" ? option.value : option;
+		return option.toString();
+	}
 
-        let stringifiedValue = toStringifiedValue(option);
-        let label;
+	$: {
+		sanitizedOptions = [];
 
-        if (_value === value) {
-            sanitizedValue = stringifiedValue;
-        }
+		for (let i = 0; i < options.length; i++) {
+			let option = options[i];
+			let optionType = typeof option;
+			let disabled =
+				optionType === 'object' && typeof option.disabled === 'boolean'
+					? option.disabled
+					: false;
+			let _value = optionType === 'object' ? option.value : option;
 
-        if (option.label) {
-            label = option.label;
-        } else {
-            label = stringifiedValue;
-        }
+			let stringifiedValue = toStringifiedValue(option);
+			let label;
 
-        sanitizedOptions[i] = {
-            label,
-            value: stringifiedValue,
-            disabled
-        };
-    }
-}
+			if (_value === value) {
+				sanitizedValue = stringifiedValue;
+			}
 
-function handleChange(event) {
-    const index = sanitizedOptions.findIndex((opt) => opt.value === event.currentTarget.value);
-    const option = options[index]
-    const newValue = typeof option === "object" ? option.value : option;
+			if (option.label) {
+				label = option.label;
+			} else {
+				label = stringifiedValue;
+			}
 
-    value = newValue;
+			sanitizedOptions[i] = {
+				label,
+				value: stringifiedValue,
+				disabled,
+			};
+		}
+	}
 
-    dispatch("change", newValue);
-}
+	function handleChange(event) {
+		const index = sanitizedOptions.findIndex(
+			(opt) => opt.value === event.currentTarget.value,
+		);
+		const option = options[index];
+		const newValue = typeof option === 'object' ? option.value : option;
 
+		value = newValue;
+
+		dispatch('change', newValue);
+	}
 </script>
 
 <div
-    class="select-input"
-    class:disabled={disabled}
-    class:single={sanitizedOptions.length === 1}
+	class="select-input"
+	class:disabled
+	class:single={sanitizedOptions.length === 1}
 >
-    <div class="container">
-        <select class="select" bind:this={node} on:change={handleChange} {name} {disabled} {title} bind:value={sanitizedValue}>
-            {#each sanitizedOptions as option}
-                <option value={option.value} selected={sanitizedValue === option.value} disabled={option.disabled}>{option.label}</option>
-            {/each}
-        </select>
-        {#if sanitizedOptions.length > 1 }
-            <SelectChevrons />
-        {/if}
-    </div>
+	<div class="container">
+		<select
+			class="select"
+			bind:this={node}
+			on:change={handleChange}
+			{name}
+			{disabled}
+			{title}
+			bind:value={sanitizedValue}
+		>
+			{#each sanitizedOptions as option}
+				<option
+					value={option.value}
+					selected={sanitizedValue === option.value}
+					disabled={option.disabled}>{option.label}</option
+				>
+			{/each}
+		</select>
+		{#if sanitizedOptions.length > 1}
+			<SelectChevrons />
+		{/if}
+	</div>
 </div>
 
 <style>
-.select-input {
-    width: 100%;
-}
+	.select-input {
+		width: 100%;
 
-.container {
-    position: relative;
+		color: var(--color-text-input);
+	}
 
-    display: flex;
-    height: var(--height-input);
-    margin: 2px 0;
+	.select-input.disabled {
+		color: var(--color-text-input-disabled);
+	}
 
-    color: rgba(255, 255, 255, 0.5);
+	.container {
+		position: relative;
 
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
-    border-radius: var(--border-radius-input);
-    background-color: var(--color-background-input);
-}
+		display: flex;
+		height: var(--height-input);
+		margin: 2px 0;
 
-.select-input:not(.disabled) .container:hover {
-    box-shadow: inset 0 0 0 1px var(--color-active);
-}
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
+		border-radius: var(--border-radius-input);
+		background-color: var(--color-background-input);
+	}
 
-.container:focus-within {
-    box-shadow: 0 0 0 2px var(--color-active);
-}
+	.select-input:not(.disabled) .container:hover {
+		box-shadow: inset 0 0 0 1px var(--color-active);
+	}
 
-.select {
-    padding: 0 var(--padding, 6px) 0 var(--padding, 6px);
+	.container:focus-within {
+		box-shadow: 0 0 0 2px var(--color-active);
+	}
 
-    width: 100%;
-    
-    color: inherit;
-    font-size: var(--font-size-input);
+	.select {
+		padding: 0 var(--padding, 6px) 0 var(--padding, 6px);
 
-    outline: 0;
-    background-color: transparent;
-}
+		width: 100%;
 
-.select-input:not(.disabled) .select {
-    cursor: pointer;
-}
+		color: inherit;
+		font-size: var(--font-size-input);
 
-:global(.field__section:hover .select-input:not(.disabled) .container) {
-    color: var(--color-text);
-}
+		outline: 0;
+		background-color: transparent;
+		opacity: 1;
+	}
 
-.select-input:not(.disabled) .select:focus {
-    color: var(--color-text);
-}
+	.select-input:not(.disabled) .select {
+		cursor: pointer;
+	}
 
-.select-input:not(.disabled) .select:hover {
-    color: var(--color-text);
-}
-
+	.select-input:not(.disabled) .select:focus {
+		color: var(--color-text);
+	}
 </style>

--- a/src/client/app/ui/fields/VectorInput.svelte
+++ b/src/client/app/ui/fields/VectorInput.svelte
@@ -1,92 +1,98 @@
 <script>
-import { createEventDispatcher } from "svelte";
-import FieldInputRow from "./FieldInputRow.svelte";
-import NumberInput from "./NumberInput.svelte";
+	import { createEventDispatcher } from 'svelte';
+	import FieldInputRow from './FieldInputRow.svelte';
+	import NumberInput from './NumberInput.svelte';
 
-export let value;
-export let suffix = "";
-export let min = -Infinity;
-export let max = Infinity;
-export let step = 0.1;
-export let locked = false;
-export let disabled = false;
-export let context = null;
-export let key = "";
+	export let value;
+	export let suffix = '';
+	export let min = -Infinity;
+	export let max = Infinity;
+	export let step = 0.1;
+	export let locked = false;
+	export let disabled = false;
+	export let context = null;
+	export let key = '';
 
-const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-$: isArray = Array.isArray(value);
-$: isObject = !isArray && typeof value === "object";
-$: components = isObject ? Object.values(value) : value;
-$: keys = isObject ? Object.keys(value) : value.map(() => undefined);
+	$: isArray = Array.isArray(value);
+	$: isObject = !isArray && typeof value === 'object';
+	$: components = isObject ? Object.values(value) : value;
+	$: keys = isObject ? Object.keys(value) : value.map(() => undefined);
 
-function dispatchChange() {
-    let needsUpdate = false;
-    for (let i = 0; i < components.length; i++) {
-        const key = isArray ? i : keys[i];
+	$: console.log('VectorInput', { disabled });
 
-        if (value[key] !== components[i]) {
-            value[key] = components[i];
-            needsUpdate = true;
-        }
-    }
+	function dispatchChange() {
+		let needsUpdate = false;
+		for (let i = 0; i < components.length; i++) {
+			const key = isArray ? i : keys[i];
 
-    if (needsUpdate) {
-        dispatch('change', value);
-    }
-}
+			if (value[key] !== components[i]) {
+				value[key] = components[i];
+				needsUpdate = true;
+			}
+		}
 
-function handleComponentChange(newValue, componentIndex) {
-    let ratio = newValue / components[componentIndex];
+		if (needsUpdate) {
+			dispatch('change', value);
+		}
+	}
 
-    if (!isFinite(ratio)) {
-        ratio = 1;
-    }
+	function handleComponentChange(newValue, componentIndex) {
+		let ratio = newValue / components[componentIndex];
 
-    components = components.map((component, index) => {
-        return index === componentIndex ? newValue : 
-            locked ? (Math.round(component * ratio * (1/step)) / (1/step)) : component;
-    });
+		if (!isFinite(ratio)) {
+			ratio = 1;
+		}
 
-    dispatchChange();
-}
+		components = components.map((component, index) => {
+			return index === componentIndex
+				? newValue
+				: locked
+				? Math.round(component * ratio * (1 / step)) / (1 / step)
+				: component;
+		});
 
+		dispatchChange();
+	}
 </script>
 
-<div class="vector-container vec{components.length}" class:locked={locked}>
-    <FieldInputRow --grid-template-columns={components.map(() => "1fr").join(" ")}>
-        {#each components as component, index}
-            <NumberInput
-                {min}
-                {max}
-                {step}
-                {suffix}
-                {disabled}
-                {context}
-                {key}
-                label={keys[index]}
-                value={component}
-                on:change={(event) => handleComponentChange(event.detail, index)}
-            />
-        {/each}
-    </FieldInputRow>
+<div class="vector-container vec{components.length}" class:locked>
+	<FieldInputRow
+		--grid-template-columns={components.map(() => '1fr').join(' ')}
+	>
+		{#each components as component, index}
+			<NumberInput
+				{min}
+				{max}
+				{step}
+				{suffix}
+				{disabled}
+				{context}
+				{key}
+				label={keys[index]}
+				value={component}
+				on:change={(event) =>
+					handleComponentChange(event.detail, index)}
+			/>
+		{/each}
+	</FieldInputRow>
 </div>
 
 <style>
-.vector-container {
-    width: 100%;
-}
+	.vector-container {
+		width: 100%;
+	}
 
-:global(.vector-container.locked .number-input:not(:last-child):after) {
-    content: '';
+	:global(.vector-container.locked .number-input:not(:last-child):after) {
+		content: '';
 
-    position: absolute;
-    top: 50%;
-    right: calc(var(--column-gap) * -1);
-    width: var(--column-gap);
-    height: 1px;
+		position: absolute;
+		top: 50%;
+		right: calc(var(--column-gap) * -1);
+		width: var(--column-gap);
+		height: 1px;
 
-    background-color: var(--color-border-input);
-}
-
+		background-color: var(--color-border-input);
+	}
 </style>

--- a/src/client/app/ui/fields/VectorInput.svelte
+++ b/src/client/app/ui/fields/VectorInput.svelte
@@ -20,8 +20,6 @@
 	$: components = isObject ? Object.values(value) : value;
 	$: keys = isObject ? Object.keys(value) : value.map(() => undefined);
 
-	$: console.log('VectorInput', { disabled });
-
 	function dispatchChange() {
 		let needsUpdate = false;
 		for (let i = 0; i < components.length; i++) {

--- a/src/client/public/css/global.css
+++ b/src/client/public/css/global.css
@@ -3,34 +3,33 @@
 	font-style: normal;
 	font-weight: 400;
 	font-display: swap;
-	src:
-		local('Jetbrains Mono Regular'),
-		local('Jetbrains-Mono-Regular'),
-		local('Jetbrains Mono'),
-		local('Jetbrains-Mono'),
+	src: local('Jetbrains Mono Regular'), local('Jetbrains-Mono-Regular'),
+		local('Jetbrains Mono'), local('Jetbrains-Mono'),
 		url('/fonts/JetBrainsMono-Regular.woff2') format('woff2');
 }
 
 :root {
-	--font-mono: "Jetbrains Mono", monospace;
+	--font-mono: 'Jetbrains Mono', monospace;
 
 	--color-lightred: #ffaeae;
 	--color-red: #ff4444;
 	--color-green: #9af49f;
-	--color-lightblack: #0E0E0E;
-	
+	--color-lightblack: #0e0e0e;
+
 	--color-background: #242425;
 	--color-active: #177bd0;
 	--color-text: #f0f0f0;
 	--color-border: var(--color-lightblack);
 	--color-border-input: #000000;
-    --color-background-input: #1d1d1e;
-    --color-spacing: #323233;
+	--color-text-input: #989899;
+	--color-text-input-disabled: #535354;
+	--color-background-input: #1d1d1e;
+	--color-spacing: #323233;
 
 	--height-input: 20px;
 	--height-topbar: 24px;
-    --border-radius-input: 3px;
-    --font-size-input: 11px;
+	--border-radius-input: 3px;
+	--font-size-input: 11px;
 }
 
 html {
@@ -63,7 +62,8 @@ body {
 	overflow: hidden;
 }
 
-ul, ol {
+ul,
+ol {
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -75,7 +75,9 @@ ul, ol {
 	scrollbar-color: var(--color-active) transparent;
 }
 
-input, select, button {
+input,
+select,
+button {
 	-webkit-appearance: none;
 	padding: 0;
 	margin: 0;
@@ -83,19 +85,23 @@ input, select, button {
 	font-family: var(--font-mono);
 }
 
-h1, h2, h3, h4, h5 {
+h1,
+h2,
+h3,
+h4,
+h5 {
 	font-weight: 400;
 	margin: 0;
 	padding: 0;
 }
 
 .visually-hidden {
-    position: absolute;
-    left: -10000px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
 }
 
 .loading {


### PR DESCRIPTION
**Summary**

This PR moves the `disabled` flag of props from the `params` object to the top level of the prop declaration, allow for disabling reactivity by supporting functions on the flag and fix design inconsistencies.

**Details**

- `disabled` is a the top level of the prop level declaration instead of inside `params`

Before:
```js
export let props = {
	toggle: {
		value: true,
		params: {
			disabled: true
		}
	}
}
```

After:
```js
export let props = {
	toggle: {
		value: true,
		disabled: true
	}
}
```

Functions are also supported, making the disabled state reactive to other prop changes.

```js
export let props = {
	toggle: {
		value: true,
		disabled: () => props.anotherProp.value === false
	}
}
```

- Fix `<Select>` disabled styles
- Semantic disabling of `<input>` to avoid keyboard focus
- Pass `disabled` down to `<FieldSection>` to avoid keyboard focus
- Fix `<CheckboxInput>` disabled styles
- Fix `<ProgressInput>` disabled styles
- Prettier formatting on modified files