### PR TITLE
Support hidden prop flag function

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -212,28 +212,32 @@ export let props = {
 }
 ```
 
-A prop can be `hidden` so it doesn't show up in the Parameters module or in `build` mode.
+A prop can be `hidden` so it doesn't show up in the Parameters module or in `build` mode. It also works with a function to toggle the hidden state depending on other prop changes.
 
 ```js
 export let props = {
-  color: {
-    value: [10, 0, 5],
+  toggle: {
+    value: true,
     hidden: __BUILD__,
   }
+  color: {
+    value: [10, 0, 5],
+    hidden: () => props.toggle.value,
+  },
 }
 ```
 
-A prop can `disabled` so it stays in the UI but inputs are disabled to display a constraint. It also works with a function to toggle the disabled state depending on other changes (another prop changes for example).
+A prop can `disabled` so it stays in the UI but inputs are disabled to display a constraint. It also works with a function to toggle the disabled state depending on other prop changes.
 
 ```js
 export let props = {
-  display: {
+  toggle: {
     value: true,
     disabled: false,
   },
   color: {
     value: [10, 0, 5],
-    disabled: () => props.display.value === false,
+    disabled: () => props.toggle.value === false,
   },
 
 }

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -97,7 +97,7 @@
 				/>
 			{/if}
 			{#each Object.keys(sketchProps) as key, i}
-				{#if !sketchProps[key].hidden}
+				{#if typeof sketchProps[key].hidden === 'function' ? !sketchProps[key].hidden() : !sketchProps[key].hidden}
 					<Field
 						context={sketchKey}
 						{key}


### PR DESCRIPTION
**Summary**

This PR enables the `hidden` flag on props to be a function. This enables to hide/show props based on other prop changes.

Example:

```js
export let props = {
  displayColor: {
    value: true,
  }
  color: {
    value: [10, 0, 5],
    hidden: () => !props.displayColor.value,
  },
}
```