### PR TITLE
Remove label confusion with new prop.displayName

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -212,6 +212,17 @@ export let props = {
 }
 ```
 
+A prop can have a `displayName` to change only what's on screen without the need to change your code. By setting `displayName` to `null`, the name will be entirely hidden and the controller of the prop will expand to the full width of the module.
+
+```js
+export let props = {
+  color0: {
+    value: true,
+    displayName: 'background' // replace 'color0' on screen by 'background'
+  }
+}
+```
+
 A prop can be `hidden` so it doesn't show up in the Parameters module or in `build` mode. It also works with a function to toggle the hidden state depending on other prop changes.
 
 ```js

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -101,6 +101,7 @@
 					<Field
 						context={sketchKey}
 						{key}
+						displayName={sketchProps[key].displayName}
 						value={sketchProps[key].value}
 						type={sketchProps[key].type}
 						disabled={typeof sketchProps[key].disabled ===

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -25,6 +25,7 @@
 	export let params = {};
 	export let type = null;
 	export let disabled = false;
+	export let displayName;
 
 	let offsetWidth;
 	let showTriggers = false;
@@ -106,10 +107,6 @@
 	$: fieldProps = composeFieldProps(params, disabled);
 	$: onTrigger = frameDebounce(onTriggers[fieldType]);
 	$: input = fields[fieldType];
-	$: label =
-		params.label !== undefined && typeof value !== 'function'
-			? params.label
-			: key;
 	$: triggerable =
 		params.triggerable !== false &&
 		((fieldType === 'number' &&
@@ -156,8 +153,8 @@
 	bind:offsetWidth
 >
 	<FieldSection
-		name={key}
-		{label}
+		{key}
+		{displayName}
 		interactive={triggerable}
 		on:click={toggleTriggers}
 		{disabled}
@@ -284,7 +281,7 @@
 		<slot />
 	</FieldSection>
 	{#if triggerable}
-		<FieldSection visible={showTriggers} secondary>
+		<FieldSection {key} visible={showTriggers} secondary>
 			<FieldTriggers
 				{triggers}
 				{onTrigger}

--- a/src/client/app/ui/FieldSection.svelte
+++ b/src/client/app/ui/FieldSection.svelte
@@ -1,9 +1,9 @@
 <script>
+	export let key;
 	export let visible = true;
 	export let secondary = false;
 	export let interactive = false;
-	export let label = '';
-	export let name = '';
+	export let displayName = key;
 	export let disabled = false;
 </script>
 
@@ -11,15 +11,16 @@
 	class="field__section"
 	class:visible
 	class:secondary
-	class:no-label={label === null}
+	class:nameless={displayName === null}
 >
 	<div class="field__infos">
-		{#if label !== null}
+		{#if displayName !== null}
 			{#if interactive}
-				<button class="field__label" {disabled} on:click>{label}</button
+				<button class="field__label" {disabled} on:click
+					>{displayName}</button
 				>
 			{:else}
-				<span class="field__label">{label}</span>
+				<span class="field__label">{displayName}</span>
 			{/if}
 		{/if}
 		<slot name="infos" />
@@ -38,7 +39,7 @@
 		column-gap: 10px;
 	}
 
-	.field__section.no-label {
+	.field__section.nameless {
 		grid-template-columns: 1fr;
 	}
 


### PR DESCRIPTION
**Summary**

There was confusion on the existing `prop.params.label`, which was used for giving a label to `<TextInput>` or change the label of a `<ButtonInput>` BUT at the same time was overriding the name of the prop displayed on screen, therefore it was impossible to set a different text between the two.

This PR enables a new `displayName` for the prop, keeping the existing `params.label` behaviour for <TextInput> and `<ButtonInput>`.

This also adds the *real* (code was there but not working) ability to display a button with a label and without a name by setting `displayName: null`, making the controller expand to the whole width of the module.