### PR TITLE
Fix hot reloading props

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -96,7 +96,7 @@
 					disabled
 				/>
 			{/if}
-			{#each Object.keys(sketchProps) as key, i}
+			{#each Object.keys(sketchProps) as key, i (key)}
 				{#if typeof sketchProps[key].hidden === 'function' ? !sketchProps[key].hidden() : !sketchProps[key].hidden}
 					<Field
 						context={sketchKey}


### PR DESCRIPTION
**Summary**

This PR fixes an issue happening when adding/removing props, as Svelte loose track of the UI already rendered without a proper `key` in the `#each` block.