### PR TITLE
Make props reactive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,9 @@
 - [Using external dependencies](./guide/external-dependencies.md)
 - [Using triggers](./guide/using-triggers.md)
 - [Hot Shader Replacement](./guide/hot-shader-replacement.md)
-- [Shortcuts](./guide/shortcuts.md)
 - [Custom renderers](./guide/custom-renderers.md)
-
+- [Reactive props](./guide/reactive-props.md)
+- [Shortcuts](./guide/shortcuts.md)
 
 ## APIs
 - [CLI](./api/CLI.md)

--- a/docs/guide/reactive-props.md
+++ b/docs/guide/reactive-props.md
@@ -1,0 +1,115 @@
+#### <sup>[fragment](../../README.md) → [Documentation](../README.md) → [Guide](../README.md#guide) → Reactive props</sup>
+<br>
+
+# Reactive props
+
+By default, `fragment` recommends declaring props as a plain JavaScript Object like this:
+
+```js
+export let props = {
+  radius: {
+    value: 20,
+  }
+};
+```
+
+However, using a plain object prevents the interface to be synchronized with changes you might apply to values directly from code. 
+
+```js
+export let init = () => {
+	let shouldChangeRadius = /*...*/;
+	
+	if (shouldChangeRadius) {
+		props.radius.value = 40; // prop.radius in the interface will still display 20, e.g the initial value of the prop
+	}
+};
+```
+
+If you need the interface to change when updating prop values, you can make the interface reacts to value changes by wrapping your props in a helper function called `reactiveProps()` available on `@fragment/helpers` namespace.
+
+```js
+import { reactiveProps } from '@fragment/helpers';
+
+export let props = reactiveProps({
+  radius: {
+    value: 20,
+  }
+});
+
+export let init = () => {
+	let shouldChangeRadius = /*...*/;
+	
+	if (shouldChangeRadius) {
+		props.radius.value = 40; // prop.radius in the interface will be updated
+	}
+};
+```
+
+By making the props *reactive* to code changes, you can enable complex behaviours such as:
+- Adding props on the fly
+
+```js
+export let init = () => {
+	onClick((event) => {
+		const sphere = retrieveSelectedObject(event);
+
+		// create new color controller
+		props.objectColor = {
+			value: sphere.color,
+		};
+
+		// create new number controller
+		props.radius = {
+			value: sphere.radius,
+			params: {
+				min: 0,
+				max: sphere.radius * 4,
+				step: 0.01,
+			}
+		};
+	});
+};
+```
+
+- Change prop params on the fly
+
+```js
+export let props = {
+	mode: {
+		value: 'mode1',
+		params: {
+			options: ['mode1', 'mode2']
+		}
+	}
+};
+
+export let init = () => {
+	onClick((event) => {
+		let shouldUpdateMode = /*...*/
+		if (shouldUpdateMode) {
+			props.mode.params.options = ['mode3', 'mode4'];
+			props.mode.value = props.mode.params.options[0];
+		}
+	});
+};
+```
+
+- Log values
+
+```js
+export let props = {
+	seed: {
+		value: generateSeed(), // seed cannot be changed from the interface but will reflect new values on click on `generate`
+		disabled: true,
+	},
+	generate: {
+		value: () => {
+			props.seed.value = generateSeed();
+		}
+	}
+};
+```
+
+## Why isn't it the recommended way of declaring props?
+
+See [`Principles → Freedom`](./about.md#freedom).

--- a/src/client/app/App.svelte
+++ b/src/client/app/App.svelte
@@ -1,7 +1,7 @@
 <script>
-import Layout from "./ui/Layout.svelte";
-import Init from "./components/Init.svelte";
-import "./client";
+	import Layout from './ui/Layout.svelte';
+	import Init from './components/Init.svelte';
+	import './client';
 </script>
 
 <Init />

--- a/src/client/app/components/Init.svelte
+++ b/src/client/app/components/Init.svelte
@@ -1,13 +1,16 @@
 <script>
-import { assignSketchFiles } from "../triggers/shared.js";
-import { sketchesKeys } from "../stores/sketches.js";
-import "../utils/glslErrors.js";
+	import { assignSketchFiles } from '../triggers/shared.js';
+	import { loadAll, sketchesKeys } from '../stores/sketches.js';
+	import { onSketchReload } from '@fragment/sketches';
+	import '../utils/glslErrors.js';
 
-sketchesKeys.subscribe((keys) => {
-	if (keys.length > 0) {
-		assignSketchFiles(keys);
-	}
-})
+	sketchesKeys.subscribe((keys) => {
+		if (keys.length > 0) {
+			assignSketchFiles(keys);
+		}
+	});
 
-
+	onSketchReload(({ sketches }) => {
+		loadAll(sketches);
+	});
 </script>

--- a/src/client/app/helpers.js
+++ b/src/client/app/helpers.js
@@ -37,10 +37,6 @@ const propsHandler = {
 	},
 };
 
-/**
- *
- * @param {Props} props
- */
 export function reactiveProps(props = {}) {
 	return new Proxy(props, propsHandler);
 }

--- a/src/client/app/helpers.js
+++ b/src/client/app/helpers.js
@@ -1,0 +1,46 @@
+import { props } from './stores/props';
+
+const propHandler = {
+	set: function (target, key, value, receiver) {
+		Reflect.set(target, key, value, receiver);
+
+		if (key === 'value') {
+			props.update((currentProps) => currentProps);
+		}
+
+		return true;
+	},
+};
+
+const propsHandler = {
+	get: (target, key) => {
+		if (typeof target[key] === 'object' && target[key] !== null) {
+			return new Proxy(target[key], propHandler);
+		}
+	},
+	set: (target, key, value) => {
+		console.log('new set', target, key, value);
+
+		target[key] = value;
+
+		props.update((currentProps) => currentProps);
+
+		return true;
+	},
+	deleteProperty: (target, prop) => {
+		if (prop in target) {
+			delete target[prop];
+			props.update((currentProps) => currentProps);
+
+			return true;
+		}
+	},
+};
+
+/**
+ *
+ * @param {Props} props
+ */
+export function reactiveProps(props = {}) {
+	return new Proxy(props, propsHandler);
+}

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -8,13 +8,13 @@
 
 <script>
 	import { onMount, onDestroy } from 'svelte';
-	import { props } from '../stores';
 	import { sketches } from '../stores/sketches.js';
 	import { monitors } from '../stores/rendering';
 	import Module from '../ui/Module.svelte';
 	import Field from '../ui/Field.svelte';
 	import OutputParams from '../ui/ParamsOutput.svelte';
 	import ModuleHeaderAction from '../ui/ModuleHeaderAction.svelte';
+	import { updateProp, props } from '../stores/props';
 
 	export let mID;
 	export let hasHeader = true;
@@ -97,32 +97,25 @@
 				/>
 			{/if}
 			{#each Object.keys(sketchProps) as key, i (key)}
-				{#if typeof sketchProps[key].hidden === 'function' ? !sketchProps[key].hidden() : !sketchProps[key].hidden}
+				{@const sketchProp = sketchProps[key]}
+				{@const { hidden, displayName, value, type, disabled } =
+					sketchProp}
+				{@const isDisabled =
+					typeof disabled === 'function' ? disabled() : disabled}
+				{#if typeof hidden === 'function' ? !hidden() : !hidden}
 					<Field
 						context={sketchKey}
 						{key}
-						displayName={sketchProps[key].displayName}
-						value={sketchProps[key].value}
-						type={sketchProps[key].type}
-						disabled={typeof sketchProps[key].disabled ===
-						'function'
-							? sketchProps[key].disabled()
-							: sketchProps[key].disabled}
+						{displayName}
+						{value}
+						{type}
+						disabled={isDisabled}
 						bind:params={sketchProps[key].params}
 						on:click={() => {
 							$props[sketchKey][key].value._refresh = true;
 						}}
 						on:change={(event) => {
-							$props[sketchKey][key].value = event.detail;
-
-							if (
-								typeof $props[sketchKey][key].onChange ===
-								'function'
-							) {
-								$props[sketchKey][key].onChange(
-									$props[sketchKey][key],
-								);
-							}
+							updateProp(sketchKey, key, event.detail);
 						}}
 					/>
 				{/if}

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -1,14 +1,15 @@
-import { writable, get } from "svelte/store";
-import { sketches } from "./sketches";
+import { sketches } from './sketches';
+import { getStore } from './utils';
 
-export const props = writable({});
+export const props = getStore('props', {});
 
 sketches.subscribe((sketches) => {
 	props.update((currentProps) => {
 		Object.keys(sketches).forEach((key) => {
 			const sketch = sketches[key];
 
-			if (sketch) { // sketch can be undefined if failed to load
+			if (sketch) {
+				// sketch can be undefined if failed to load
 				currentProps[key] = reconcile(sketch.props, currentProps[key]);
 			}
 		});
@@ -17,7 +18,7 @@ sketches.subscribe((sketches) => {
 	});
 });
 
-function reconcile(newProps = {}, prevProps = {}) {
+export function reconcile(newProps = {}, prevProps = {}) {
 	Object.keys(newProps).forEach((propKey) => {
 		let newProp = newProps[propKey];
 
@@ -43,4 +44,26 @@ function reconcile(newProps = {}, prevProps = {}) {
 	}
 
 	return newProps;
+}
+
+/**
+ * Update prop value based on sketch key and prop key
+ * @param {string} sketchKey
+ * @param {string} propKey
+ * @param {any} newValue
+ */
+export function updateProp(sketchKey, propKey, newValue) {
+	props.update((currentProps) => {
+		const prop = currentProps[sketchKey][propKey];
+
+		if (prop) {
+			prop.value = newValue;
+
+			if (typeof prop.onChange === 'function') {
+				prop.onChange(prop);
+			}
+		}
+
+		return currentProps;
+	});
 }

--- a/src/client/app/stores/sketches.js
+++ b/src/client/app/stores/sketches.js
@@ -1,6 +1,6 @@
-import { createStore } from "./utils.js";
-import { displayError } from "../stores/errors";
-import { sketches as all, onSketchReload } from "@fragment/sketches";
+import { createStore } from './utils.js';
+import { displayError } from '../stores/errors';
+import { sketches as all } from '@fragment/sketches';
 
 export const sketches = createStore('sketches', {});
 export const sketchesKeys = createStore('sketchesKeys', Object.keys(all));
@@ -16,9 +16,11 @@ async function loadSketch(collection, key) {
 	}
 }
 
-async function loadAll(collection) {
+export async function loadAll(collection) {
 	const keys = [...Object.keys(collection)];
-	const loadedSketches = await Promise.all(keys.map((key) => loadSketch(collection, key)));
+	const loadedSketches = await Promise.all(
+		keys.map((key) => loadSketch(collection, key)),
+	);
 
 	const newSketches = keys.reduce((all, key, index) => {
 		if (loadedSketches[index]) {
@@ -34,7 +36,3 @@ async function loadAll(collection) {
 }
 
 loadAll(all);
-
-onSketchReload(({ sketches }) => {
-	loadAll(sketches);
-});

--- a/src/client/app/stores/utils.js
+++ b/src/client/app/stores/utils.js
@@ -36,7 +36,7 @@ export function save(key, value) {
  * @param {string} key
  * @param {any} initialValue
  * @param {object} options
- * @returns {object} store
+ * @returns {import('svelte/store').Writable} store
  */
 export function createStore(
 	key,
@@ -63,7 +63,7 @@ export function createStore(
  * @param {string} key
  * @param {any} initialValue
  * @param {object} options
- * @returns {object} store
+ * @returns {import('svelte/store').Writable} store
  */
 export function getStore(
 	key,

--- a/src/client/app/ui/FieldGroup.svelte
+++ b/src/client/app/ui/FieldGroup.svelte
@@ -1,103 +1,115 @@
 <script>
-export let name;
+	export let name;
 
-export let collapsed = false;
+	export let collapsed = false;
 
-function handleClick() {
-    collapsed = !collapsed;
-}
-
+	function handleClick() {
+		collapsed = !collapsed;
+	}
 </script>
 
-<div class="field-group {collapsed ? "collapsed" : ""}">
-    <header class="header">
-        <button class="header__action" on:click={handleClick}>
-            <svg class="header__icon" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.75 8.75L14.25 12L10.75 15.25"/>
-            </svg>
-            <span class="field-group__name">{name}</span>
-        </button>
-    </header>
-    <div class="content">
-        <slot></slot>
-    </div>
+<div class="field-group {collapsed ? 'collapsed' : ''}">
+	<header class="header">
+		<button class="header__action" on:click={handleClick}>
+			<svg
+				class="header__icon"
+				width="24"
+				height="24"
+				fill="none"
+				viewBox="0 0 24 24"
+			>
+				<path
+					stroke="currentColor"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="1.5"
+					d="M10.75 8.75L14.25 12L10.75 15.25"
+				/>
+			</svg>
+			<span class="field-group__name">{name}</span>
+		</button>
+	</header>
+	<div class="content">
+		<slot />
+	</div>
 </div>
 
 <style>
-.field-group {
-    position: relative;
+	.field-group {
+		position: relative;
 
-    display: grid;
-    width: 100%;
-    
-}
+		display: grid;
+		width: 100%;
+	}
 
-.field-group:after {
-    content: "";
+	.field-group:after {
+		content: '';
 
-    position: absolute;
-    left: 0;
-    bottom: 0px;
-    
-    width: 12px;
-    height: 1px;
-    
-    background-color: #323233;
-}
+		position: absolute;
+		left: 0;
+		bottom: 0px;
 
-.header {
-    padding: 3px 6px;
-    border-bottom: 1px solid #323233;
-}
+		width: 12px;
+		height: 1px;
 
-.header__action {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    text-align: left;
+		background-color: #323233;
+	}
 
-    background: transparent;
-    cursor: pointer;
-}
+	.header {
+		padding: 3px 6px;
+		border-bottom: 1px solid #323233;
+	}
 
-.header__icon {
-    padding-bottom: 1px;
+	.header__action {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		text-align: left;
 
-    color: #f0f0f0;
-    transform: rotate(90deg);
-    opacity: 0.5;
-    transition: opacity 0.1s ease;
-}
+		background: transparent;
+		cursor: pointer;
+		outline: 0;
+	}
 
-.header__action:hover .header__icon {
-    opacity: 1;
-}
+	.header__icon {
+		padding-bottom: 1px;
 
-.field-group.collapsed .header__icon {
-    transform: rotate(0deg);
-}
+		color: #f0f0f0;
+		transform: rotate(90deg);
+		opacity: 0.5;
+		transition: opacity 0.1s ease;
+	}
 
-.field-group__name {
-    color: #f0f0f0;
+	.header__action:hover .header__icon {
+		opacity: 1;
+	}
 
-    font-size: 11px;
-    font-weight: 700;
-    /* text-transform: uppercase; */
+	.field-group.collapsed .header__icon {
+		transform: rotate(0deg);
+	}
 
-    opacity: 0.75;
-    transition: opacity 0.1s ease;
-}
+	.field-group__name {
+		color: #f0f0f0;
 
-.header__action:hover .field-group__name {
-    opacity: 1;
-}
+		font-size: 11px;
+		font-weight: 700;
+		/* text-transform: uppercase; */
 
-.content {
-    margin-left: 12px;
-    border-left: 1px solid #323233;
-}
+		opacity: 0.75;
+		transition: opacity 0.1s ease;
+	}
 
-.field-group.collapsed .content {
-    display: none;
-}
+	.header__action:hover .field-group__name,
+	.header__action:focus-visible .field-group__name {
+		opacity: 1;
+	}
+
+	.content {
+		margin-left: 12px;
+		border-left: 1px solid #323233;
+	}
+
+	.field-group.collapsed .content {
+		display: none;
+	}
 </style>

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
-	import { derived, get } from 'svelte/store';
+	import { derived } from 'svelte/store';
 	import KeyBinding from '../components/KeyBinding.svelte';
 	import { sketches, sketchesKeys } from '../stores/sketches.js';
 	import { layout } from '../stores/layout.js';

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
-	import { derived } from 'svelte/store';
+	import { derived, get } from 'svelte/store';
 	import KeyBinding from '../components/KeyBinding.svelte';
 	import { sketches, sketchesKeys } from '../stores/sketches.js';
 	import { layout } from '../stores/layout.js';
@@ -541,12 +541,6 @@
 		}
 	}
 
-	sketches.subscribe(() => {
-		if (_created || _errored) {
-			createSketch(key);
-		}
-	});
-
 	sync.subscribe(() => {
 		if (_created) {
 			_renderSketch = createRenderLoop();
@@ -555,6 +549,12 @@
 
 	onMount(() => {
 		createSketch(key);
+
+		sketches.subscribe(() => {
+			if (_created || _errored) {
+				createSketch(key);
+			}
+		});
 
 		client.on('shader-update', () => {
 			if (framerate === 0) {

--- a/src/client/app/ui/fields/ButtonInput.svelte
+++ b/src/client/app/ui/fields/ButtonInput.svelte
@@ -47,6 +47,7 @@
 		);
 		box-shadow: inset 0 0 0 1px
 			var(--box-shadow-color, var(--color-border-input));
+		outline: 0;
 	}
 
 	.button:disabled {
@@ -60,7 +61,8 @@
 			var(--box-shadow-color-active, var(--color-active));
 	}
 
-	.button:active {
+	.button:active,
+	.button:focus-visible {
 		box-shadow: 0 0 0 2px
 			var(--box-shadow-color-active, var(--color-active));
 	}

--- a/src/client/app/ui/fields/CheckboxInput.svelte
+++ b/src/client/app/ui/fields/CheckboxInput.svelte
@@ -51,6 +51,7 @@
 		border: none;
 		border-radius: var(--border-radius-input);
 		background-color: transparent;
+		outline: 0;
 	}
 
 	.checked {

--- a/src/client/app/ui/fields/ImageInput.svelte
+++ b/src/client/app/ui/fields/ImageInput.svelte
@@ -1,85 +1,88 @@
 <script>
-import { onMount } from "svelte";
-import { loadImage } from "../../lib/loader/loadImage";
-import ButtonInput from "./ButtonInput.svelte";
-import FieldInputRow from "./FieldInputRow.svelte";
-import TextInput from "./TextInput.svelte";
+	import { onMount } from 'svelte';
+	import { loadImage } from '../../lib/loader/loadImage';
+	import ButtonInput from './ButtonInput.svelte';
+	import FieldInputRow from './FieldInputRow.svelte';
+	import TextInput from './TextInput.svelte';
 
-export let value;
-export let context = null;
-export let key = "";
+	export let value;
+	export let context = null;
+	export let key = '';
+	export let disabled = false;
 
-let img, input, name;
-$: url = typeof value === HTMLImageElement ? value.src : value;
-$: displayUrl = name ? name : url.replace(`/@fs${__CWD__}`, '');
-$: {
-	;(async () => {
-		await loadImage(url, { img });
-	})();
-}
+	let img, input, name;
+	$: url = typeof value === HTMLImageElement ? value.src : value;
+	$: displayUrl = name ? name : url.replace(`/@fs${__CWD__}`, '');
+	$: {
+		(async () => {
+			await loadImage(url, { img });
+		})();
+	}
 
-function handleClick() {
-	input.click();
-}
+	function handleClick() {
+		input.click();
+	}
 
-let reader = new FileReader();
-let dragover = false;
+	let reader = new FileReader();
+	let dragover = false;
 
-function handleUpload(event) {
-	event.preventDefault();
-	event.stopPropagation();
+	function handleUpload(event) {
+		event.preventDefault();
+		event.stopPropagation();
 
-	let file;
+		let file;
 
-	if (event.dataTransfer) {
-        file = event.dataTransfer.files[0];
-	} else if(event.target) {
-        file = event.target.files[0];
-    }
+		if (event.dataTransfer) {
+			file = event.dataTransfer.files[0];
+		} else if (event.target) {
+			file = event.target.files[0];
+		}
 
-    name = file.name;
+		name = file.name;
 
-    reader.onload = async (e) => {
-		reader.onload = null;
+		reader.onload = async (e) => {
+			reader.onload = null;
 
-		value = e.target.result;
-    };
-	reader.readAsDataURL(file);
+			value = e.target.result;
+		};
+		reader.readAsDataURL(file);
 
-	dragover = false;
-}
+		dragover = false;
+	}
 
-function handleDragover(event) {
-	event.preventDefault();
-	event.stopPropagation();
+	function handleDragover(event) {
+		event.preventDefault();
+		event.stopPropagation();
 
-	dragover = true;
-}
+		dragover = true;
+	}
 
-function handleDragleave(event) {
-	event.preventDefault();
-	event.stopPropagation();
+	function handleDragleave(event) {
+		event.preventDefault();
+		event.stopPropagation();
 
-	dragover = false;
-}
-
+		dragover = false;
+	}
 </script>
 
 <div
 	class="img-container"
-	class:dragover={dragover}
+	class:dragover
 	on:dragover={handleDragover}
 	on:dragleave={handleDragleave}
 	on:drop={handleUpload}
 >
 	<FieldInputRow --grid-template-columns="1fr 0.5fr">
 		<div class="row">
-			<div
-				class="preview"
-				on:click={handleClick}
-			>
-				<img class="img" src="" alt="" bind:this={img}/>
-				<input class="input" type="file" bind:this={input} on:change={handleUpload} />
+			<div class="preview" on:click={handleClick}>
+				<img class="img" src="" alt="" bind:this={img} />
+				<input
+					class="input"
+					type="file"
+					bind:this={input}
+					on:change={handleUpload}
+					disabled={disabled ? 'disabled' : null}
+				/>
 			</div>
 			<TextInput disabled value={displayUrl} />
 		</div>
@@ -89,59 +92,58 @@ function handleDragleave(event) {
 			on:dragover={handleDragover}
 			on:dragleave={handleDragleave}
 			on:drop={handleUpload}
+			{disabled}
 		/>
 	</FieldInputRow>
-	
 </div>
 
 <style>
-.img-container {
-	width: 100%;
-}
+	.img-container {
+		width: 100%;
+	}
 
-.preview {
-	width: calc(var(--height-input) * 1);
-	height: calc(var(--height-input) * 1);
-;
-	display: grid;
-	place-items: center;
+	.preview {
+		width: calc(var(--height-input) * 1);
+		height: calc(var(--height-input) * 1);
+		display: grid;
+		place-items: center;
 
-	border-radius: var(--border-radius-input);
-    background-color: var(--color-background-input);
-    box-shadow: inset 0 0 0 1px var(--color-border-input);
+		border-radius: var(--border-radius-input);
+		background-color: var(--color-background-input);
+		box-shadow: inset 0 0 0 1px var(--color-border-input);
 
-	cursor: copy;
-	overflow: hidden;
-}
+		cursor: copy;
+		overflow: hidden;
+	}
 
-.row {
-	display: grid;
-	grid-template-columns: 20px auto;
-	gap: var(--column-gap);
-	place-items: center;
-}
+	.row {
+		display: grid;
+		grid-template-columns: 20px auto;
+		gap: var(--column-gap);
+		place-items: center;
+	}
 
-.preview:hover {
-    color: var(--color-text);
+	.preview:hover {
+		color: var(--color-text);
 
-    box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-active));
-}
+		box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-active));
+	}
 
-.preview:active, .img-container.dragover .preview {
-    box-shadow: 0 0 0 2px var(--box-shadow-color, var(--color-active));
-}
+	.preview:active,
+	.img-container.dragover .preview {
+		box-shadow: 0 0 0 2px var(--box-shadow-color, var(--color-active));
+	}
 
-.img-container.dragover {
-	cursor: copy;
-}
+	.img-container.dragover {
+		cursor: copy;
+	}
 
-.img {
-	max-width: calc(100% - var(--padding) * 0.5);
-	max-height: calc(100% - var(--padding) * 0.5);
-}
+	.img {
+		max-width: calc(100% - var(--padding) * 0.5);
+		max-height: calc(100% - var(--padding) * 0.5);
+	}
 
-.input {
-	display: none;
-}
-
+	.input {
+		display: none;
+	}
 </style>


### PR DESCRIPTION
**Summary**

This PR enables *reactive props* through a newly exposed **hook**, making it easier to build conditional props, adding new props on the fly or simply reflect prop values changed from code.

Example:

```js
export let props = reactiveProps({
  radius: {
    value: 20,
  }
});

export let init = () => {
 onClick(() => props.radius.value = 40); // update the interface
};
```

**Details**

- Expose new `@fragment/hooks` with `reactiveProps()` function
- Add documentation
- Fix focus state of `ButtonInput`, `CheckboxInput` and `FieldGroup`
- Prettify modified files