### PR TITLE
Fix triggers when used with wildcard or number argument

### DIFF
--- a/src/client/app/inputs/Keyboard.js
+++ b/src/client/app/inputs/Keyboard.js
@@ -1,21 +1,19 @@
-import Input from "./Input";
+import Input from './Input';
 
 class Keyboard extends Input {
+	/**
+	 *
+	 * @param {KeyboardEvent} event
+	 */
+	getStepFromEvent(event) {
+		if (event.shiftKey) {
+			return 10;
+		} else if (event.altKey) {
+			return 0.1;
+		}
 
-    /**
-     * 
-     * @param {KeyboardEvent} event 
-     */
-    getStepFromEvent(event) {
-        if (event.shiftKey) {
-            return 10;
-        } else if (event.altKey) {
-            return 0.1;
-        }
-
-        return 1;
-    }
-
+		return 1;
+	}
 }
 
 export default new Keyboard();

--- a/src/client/app/inputs/MIDI.js
+++ b/src/client/app/inputs/MIDI.js
@@ -1,17 +1,16 @@
-import Input from "./Input";
+import Input from './Input';
 
 const commands = {
-	0x8: "noteoff",
-	0x9: "noteon",
-	0xB: "controlchange",
+	0x8: 'noteoff',
+	0x9: 'noteon',
+	0xb: 'controlchange',
 };
 
-const notes = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
-const LOCAL_STORAGE_KEY = "midi.requested";
+const LOCAL_STORAGE_KEY = 'midi.requested';
 
 class MIDI extends Input {
-
 	constructor() {
 		super();
 
@@ -42,25 +41,25 @@ class MIDI extends Input {
 
 		if (this.inputs.size === 1) {
 			const [entry] = this.inputs.values();
-			const { id } = entry; 
+			const { id } = entry;
 
 			this.selectedInputID = id;
 		}
 
 		if (this.outputs.size === 1) {
 			const [entry] = this.outputs.values();
-			const { id } = entry; 
+			const { id } = entry;
 
 			this.selectedOutputID = id;
 		}
 	}
 
 	attachListeners() {
-		this.inputs.forEach(entry => {
+		this.inputs.forEach((entry) => {
 			entry.onmidimessage = (event) => {
 				this.onMessage(event);
 			};
-		})
+		});
 	}
 
 	addEventListener(eventName, fn) {
@@ -76,14 +75,14 @@ class MIDI extends Input {
 		let type = commands[command];
 
 		let channel = (event.data[0] & 0xf) + 1;
-    	let data1 = event.data[1]
+		let data1 = event.data[1];
 		let data2 = event.data[2];
 
 		let note = {
 			number: data1,
 			name: notes[data1 % 12],
 		};
-		
+
 		let velocity = data2 / 127;
 		let rawVelocity = data2;
 
@@ -117,7 +116,7 @@ class MIDI extends Input {
 		if (this.listeners.has(eventName)) {
 			const listeners = this.listeners.get(eventName);
 
-			listeners.forEach(listener => listener(data));
+			listeners.forEach((listener) => listener(data));
 		}
 	}
 
@@ -135,7 +134,7 @@ class MIDI extends Input {
 				this.requesting = false;
 				this.start();
 			}
-		} catch(error) {
+		} catch (error) {
 			this.handleError(error);
 		}
 	}

--- a/src/client/app/triggers/Keyboard.js
+++ b/src/client/app/triggers/Keyboard.js
@@ -66,7 +66,7 @@ function createTrigger(eventName, collection) {
 
 		const keys = Array.isArray(key)
 			? key
-			: [...key.split(',').map((k) => (k !== ' ' ? k.trim() : k))];
+			: [...`${key}`.split(',').map((k) => (k !== ' ' ? k.trim() : k))];
 
 		const trigger = new Trigger({
 			inputType: 'Keyboard',

--- a/src/client/app/triggers/Keyboard.js
+++ b/src/client/app/triggers/Keyboard.js
@@ -1,95 +1,104 @@
-import Trigger from "./Trigger";
-import Keyboard from "../inputs/Keyboard";
-import { wildcard, getContext } from "./shared";
-import { addToMapArray, removeFromMapArray } from "../utils";
+import Trigger from './Trigger';
+import Keyboard from '../inputs/Keyboard';
+import { wildcard, getContext } from './shared';
+import { addToMapArray, removeFromMapArray } from '../utils';
 
 const pressedKeys = new Map();
 const upKeys = new Map();
 const downKeys = new Map();
 
 export const removeHotListeners = (context) => {
-    function removeHotFrom(collection) {
-        for (let trigger of collection) {
-            const [key, triggers] = trigger;
-            
-            collection.set(key, triggers.filter((trigger) => trigger.context !== context));
-        }
-    }
+	function removeHotFrom(collection) {
+		for (let trigger of collection) {
+			const [key, triggers] = trigger;
 
-    removeHotFrom(pressedKeys);
-    removeHotFrom(upKeys);
-    removeHotFrom(downKeys);
+			collection.set(
+				key,
+				triggers.filter((trigger) => trigger.context !== context),
+			);
+		}
+	}
+
+	removeHotFrom(pressedKeys);
+	removeHotFrom(upKeys);
+	removeHotFrom(downKeys);
 };
 
 function createEventListener(collection) {
-    return (event) => {
-        const { key, target } = event;
+	return (event) => {
+		const { key, target } = event;
 
-        if (!target.classList.contains('input')) {
-            const triggers = [
-                ...(collection.has(key) ? collection.get(key) : []),
-                ...(collection.has(wildcard) ? collection.get(wildcard) : []),
-            ];
+		if (!target.classList.contains('input')) {
+			const triggers = [
+				...(collection.has(key) ? collection.get(key) : []),
+				...(collection.has(wildcard) ? collection.get(wildcard) : []),
+			];
 
-            triggers.forEach(trigger => {
-                if (!Keyboard.enabled) return;
-                
-                trigger.run(event);
-            });
-        }
-    };
+			triggers.forEach((trigger) => {
+				if (!Keyboard.enabled) return;
+
+				trigger.run(event);
+			});
+		}
+	};
 }
 
 function createTrigger(eventName, collection) {
-    return (key, fn, options = {}) => {
-        if (typeof key === "function") {
-            if (typeof fn === "object") {
-                options = {
-                    ...options,
-                    ...fn,
-                };
-            }
+	return (key, fn, options = {}) => {
+		if (typeof key === 'function') {
+			if (typeof fn === 'object') {
+				options = {
+					...options,
+					...fn,
+				};
+			}
 
-            fn = key;
-            key = "*";
+			fn = key;
+			key = '*';
 
-            if (options.key) {
-                key = options.key;
-            }
-        }
+			if (options.key) {
+				key = options.key;
+			}
+		}
 
-        const { hot, enabled, ...params } = options;
-        const context = getContext();
+		const { hot, enabled, ...params } = options;
+		const context = getContext();
 
-        const keys = Array.isArray(key) ? key : [...key.split(',').map(k => k !== " " ? k.trim() : k)];
-        
-        const trigger = new Trigger({
-            inputType: 'Keyboard',
-            eventName,
-            fn,
-            context,
-            params: {...params, key: keys },
-            hot,
-            enabled,
-            destroy: () => {
-                keys.forEach((key) => {
-                    removeFromMapArray(collection, key, (item) => item.id === trigger.id);
-                });
-            }
-        });
+		const keys = Array.isArray(key)
+			? key
+			: [...key.split(',').map((k) => (k !== ' ' ? k.trim() : k))];
 
-        keys.forEach(key => {
-            addToMapArray(collection, key, trigger);
-        });
+		const trigger = new Trigger({
+			inputType: 'Keyboard',
+			eventName,
+			fn,
+			context,
+			params: { ...params, key: keys },
+			hot,
+			enabled,
+			destroy: () => {
+				keys.forEach((key) => {
+					removeFromMapArray(
+						collection,
+						key,
+						(item) => item.id === trigger.id,
+					);
+				});
+			},
+		});
 
-        return trigger;
-    };
-};
+		keys.forEach((key) => {
+			addToMapArray(collection, key, trigger);
+		});
 
-window.addEventListener("keypress", createEventListener(pressedKeys));
-window.addEventListener("keyup", createEventListener(upKeys));
-window.addEventListener("keydown", createEventListener(downKeys));
+		return trigger;
+	};
+}
+
+window.addEventListener('keypress', createEventListener(pressedKeys));
+window.addEventListener('keyup', createEventListener(upKeys));
+window.addEventListener('keydown', createEventListener(downKeys));
 
 export const onKeyPress = createTrigger('onKeyPress', pressedKeys);
-export const onKeyDown = createTrigger('onKeyDown', downKeys); 
+export const onKeyDown = createTrigger('onKeyDown', downKeys);
 export const onKeyUp = createTrigger('onKeyUp', upKeys);

--- a/src/client/app/triggers/MIDI.js
+++ b/src/client/app/triggers/MIDI.js
@@ -1,7 +1,7 @@
-import Trigger from "./Trigger";
-import MIDI from "../inputs/MIDI.js";
-import { addToMapArray, removeFromMapArray } from "../utils";
-import { wildcard, getContext } from "./shared";
+import Trigger from './Trigger';
+import MIDI from '../inputs/MIDI.js';
+import { addToMapArray, removeFromMapArray } from '../utils';
+import { wildcard, getContext } from './shared';
 
 const noteons = new Map();
 const noteoffs = new Map();
@@ -11,33 +11,36 @@ const controlchanges = new Map();
 
 /**
  * Remove listeners from a specific context
- * @param {string} context 
+ * @param {string} context
  */
 export const removeHotListeners = (context) => {
-    function removeHotFrom(collection) {
-        for (let trigger of collection) {
-            const [key, triggers] = trigger;
-            
-            collection.set(key, triggers.filter((trigger) => trigger.context !== context));
-        }
-    }
+	function removeHotFrom(collection) {
+		for (let trigger of collection) {
+			const [key, triggers] = trigger;
 
-    removeHotFrom(noteons);
-    removeHotFrom(noteoffs);
-    removeHotFrom(numberons);
-    removeHotFrom(numberoffs);
-    removeHotFrom(controlchanges);
+			collection.set(
+				key,
+				triggers.filter((trigger) => trigger.context !== context),
+			);
+		}
+	}
+
+	removeHotFrom(noteons);
+	removeHotFrom(noteoffs);
+	removeHotFrom(numberons);
+	removeHotFrom(numberoffs);
+	removeHotFrom(controlchanges);
 };
 
 /**
  * Check all registered listeners for a specific key
- * @param {Map} collection 
- * @param {function} getKey 
+ * @param {Map} collection
+ * @param {function} getKey
  * @returns {function} listener
  */
 function createEventListener(collection, getKey = (event) => event.key) {
-    return (event) => {
-        const key = getKey(event);
+	return (event) => {
+		const key = getKey(event);
 		const { id } = event.srcElement;
 
 		const triggers = [
@@ -46,78 +49,101 @@ function createEventListener(collection, getKey = (event) => event.key) {
 		];
 
 		if (MIDI.enabled && id === MIDI.selectedInputID) {
-			triggers.forEach(trigger => {
+			triggers.forEach((trigger) => {
 				trigger.run(event);
 			});
 		}
-    };
+	};
 }
 
 /**
  * Create a registering function for a specific event
- * @param {string} eventName 
- * @param {Map} collection 
- * @returns {function} createListener 
+ * @param {string} eventName
+ * @param {Map} collection
+ * @returns {function} createListener
  */
 function createTrigger(eventName, collection) {
-    return (key, fn, options = {}) => {
-        if (typeof key === "function") {
-            if (typeof fn === "object") {
-                options = {
-                    ...options,
-                    ...fn,
-                };
-            }
+	return (key, fn, options = {}) => {
+		if (typeof key === 'function') {
+			if (typeof fn === 'object') {
+				options = {
+					...options,
+					...fn,
+				};
+			}
 
-            fn = key;
-            key = "*";
+			fn = key;
+			key = '*';
 
-            if (options.key) {
-                key = options.key;
-            }
-        }
+			if (options.key) {
+				key = options.key;
+			}
+		}
 
-        const { hot, enabled, ...params } = options;
-        let keys = Array.isArray(key) ? key : [...key.split(',').map(k => k.trim())];
+		const { hot, enabled, ...params } = options;
+		let keys = Array.isArray(key)
+			? key
+			: [...key.split(',').map((k) => k.trim())];
 
-        if (["onControlChange", "onNumberOn", "onNumberOff"].includes(eventName)) {
-            keys = keys.map((k) => Number(k));
-        }
+		if (
+			['onControlChange', 'onNumberOn', 'onNumberOff'].includes(eventName)
+		) {
+			keys = keys.map((k) => Number(k));
+		}
 
-        if (!MIDI.enabled) {
-            MIDI.request();
-        }
+		if (!MIDI.enabled) {
+			MIDI.request();
+		}
 
-        const context = getContext();
+		const context = getContext();
 
-        const trigger = new Trigger({
-            inputType: 'MIDI',
-            eventName,
-            fn,
-            params: {...params, key: keys },
-            hot,
-            context,
-            enabled,
-            destroy : () => {
-                keys.forEach((key) => {
-                    removeFromMapArray(collection, key, (item) => item.id === trigger.id);
-                });
-            }
-        });
+		const trigger = new Trigger({
+			inputType: 'MIDI',
+			eventName,
+			fn,
+			params: { ...params, key: keys },
+			hot,
+			context,
+			enabled,
+			destroy: () => {
+				keys.forEach((key) => {
+					removeFromMapArray(
+						collection,
+						key,
+						(item) => item.id === trigger.id,
+					);
+				});
+			},
+		});
 
-        keys.forEach(k => {
-            addToMapArray(collection, k, trigger);
-        });
+		keys.forEach((k) => {
+			addToMapArray(collection, k, trigger);
+		});
 
-        return trigger;
-    };
-};
+		return trigger;
+	};
+}
 
-MIDI.addEventListener("noteon", createEventListener(noteons, (event) => event.note.name));
-MIDI.addEventListener("noteoff", createEventListener(noteoffs, (event) => event.note.name));
-MIDI.addEventListener("noteon", createEventListener(numberons, (event) => event.note.number));
-MIDI.addEventListener("noteoff", createEventListener(numberoffs, (event) => event.note.number));
-MIDI.addEventListener("controlchange", createEventListener(controlchanges, (event) => event.note.number));
+MIDI.addEventListener(
+	'noteon',
+	createEventListener(noteons, (event) => event.note.name),
+);
+MIDI.addEventListener(
+	'noteoff',
+	createEventListener(noteoffs, (event) => event.note.name),
+);
+MIDI.addEventListener(
+	'noteon',
+	createEventListener(numberons, (event) => event.note.number),
+);
+MIDI.addEventListener(
+	'noteoff',
+	createEventListener(numberoffs, (event) => event.note.number),
+);
+MIDI.addEventListener(
+	'controlchange',
+	createEventListener(controlchanges, (event) => event.note.number),
+);
 
 export const onNoteOn = createTrigger('onNoteOn', noteons);
 export const onNoteOff = createTrigger('onNoteOff', noteoffs);

--- a/src/client/app/triggers/MIDI.js
+++ b/src/client/app/triggers/MIDI.js
@@ -83,12 +83,12 @@ function createTrigger(eventName, collection) {
 		const { hot, enabled, ...params } = options;
 		let keys = Array.isArray(key)
 			? key
-			: [...key.split(',').map((k) => k.trim())];
+			: [...`${key}`.split(',').map((k) => k.trim())];
 
 		if (
 			['onControlChange', 'onNumberOn', 'onNumberOff'].includes(eventName)
 		) {
-			keys = keys.map((k) => Number(k));
+			keys = keys.map((k) => (!isNaN(Number(k)) ? Number(k) : k));
 		}
 
 		if (!MIDI.enabled) {


### PR DESCRIPTION
This PR fixes the bug happening when using triggers with a single function argument or a number argument instead of string.

**Details**

When using a trigger with a single function argument triggers are registered under a wildcard `*`. When an input such as Keyboard, Mouse or MIDI is triggered, Fragment look up if callbacks have been registered in the matching input Map and collect all the callbacks matching the input event `key` or the wildcard `*`. 

```js
import { MIDI } from '@fragment/triggers';

export let init = () => {
  MIDI.onControlChange(4, (e) => {
    console.log(e); // this callback is registered under the key 4
  });
  
  MIDI.onControlChange((e) => {
    console.log(e); // this callback is registered under the wildcard "*" 
  });
}
```

There were 2 problems with the current implementation. First, there was a JavaScript error when using an argument of type `number` as the implementation expected a string to also support multiple `keys` with a single declaration when separated with a `,`.

```js
  MIDI.onControlChange('1, 2, 3, 4', (e) => {
    console.log(e); // this callback is registered under the key 4
  });
```

Secondly, on the MIDI implementation, the keys used to register the callbacks were expected to be numbers and are casted as such, or when fallbacking to the wildcard the code was `Number('*')` which registered the callbacks under `NaN`, preventing them to be retrieved later on.
