### PR TITLE
Access width height and pixelRatio from prop onChange callback

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -213,6 +213,28 @@ export let props = {
 }
 ```
 
+The `onChange` callback provides two arguments: the first is the prop object that has changed, the second is an object containing `width`, `height`, and `pixelRatio` that are passed to lifecycle functions.
+
+```js
+export let props = {
+  color: {
+    value: [1, 0, 0],
+    type: "color",
+    onChange: (prop, { width, height, pixelRatio }) => {
+      console.log(prop === props.color); // true
+      createElement(width, height, prop.value);
+    },
+  }
+}
+
+function createElement(width, height, color) { /*...*/ }
+
+export let init = ({ width, height }) => {
+  createElement(width, height, props.color.value)
+}
+```
+
+
 A prop can have a `displayName` to change only what's on screen without the need to change your code. By setting `displayName` to `null`, the name will be entirely hidden and the controller of the prop will expand to the full width of the module.
 
 ```js

--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -9,7 +9,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import { sketches } from '../stores/sketches.js';
-	import { monitors } from '../stores/rendering';
+	import { monitors, rendering } from '../stores/rendering';
 	import Module from '../ui/Module.svelte';
 	import Field from '../ui/Field.svelte';
 	import OutputParams from '../ui/ParamsOutput.svelte';
@@ -115,7 +115,11 @@
 							$props[sketchKey][key].value._refresh = true;
 						}}
 						on:change={(event) => {
-							updateProp(sketchKey, key, event.detail);
+							updateProp(sketchKey, key, event.detail, {
+								width: $rendering.width,
+								height: $rendering.height,
+								pixelRatio: $rendering.pixelRatio,
+							});
 						}}
 					/>
 				{/if}

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -52,7 +52,7 @@ export function reconcile(newProps = {}, prevProps = {}) {
  * @param {string} propKey
  * @param {any} newValue
  */
-export function updateProp(sketchKey, propKey, newValue) {
+export function updateProp(sketchKey, propKey, newValue, params = {}) {
 	props.update((currentProps) => {
 		const prop = currentProps[sketchKey][propKey];
 
@@ -60,7 +60,7 @@ export function updateProp(sketchKey, propKey, newValue) {
 			prop.value = newValue;
 
 			if (typeof prop.onChange === 'function') {
-				prop.onChange(prop);
+				prop.onChange(prop, params);
 			}
 		}
 


### PR DESCRIPTION
This PR solves an issue when you need to access `width`, `height` or `pixelRatio` from the `onChange` listener of a prop.

Previously, this was a bit tricky if you needed to recompute stuff on prop change that relies on `width`, `height` or `pixelRatio`. One thing you could do was to store them somewhere locally:

```js
let _width, _height;

export let props = {
	scale: {
		value: 0.1,
		onChange: ({ value }) => {
		 createElement(_width, _height, value);
		}
	}
};

function createElement(w, h, scale) {
	let elementWidth = w * scale;
	/*...*/
}

export let init = ({ width, height }) => {
	createElement(width, height, props.scale.value);
};

export let resize = ({ width, height }) => {
	_width = width;
	_height = height;
}
```

Now, the `onChange` callback provides `width`, `height` or `pixelRatio` as a second parameter object such as:

```js
export let props = {
	scale: {
		value: 0.1,
		onChange: ({ value }, { width, height }) => {
		 createElement(width, height, value); // width and height are available directly here
		}
	}
};

function createElement(w, h, scale) {
	let elementWidth = w * scale;
	/*...*/
}

export let init = ({ width, height }) => {
	createElement(width, height, props.scale.value);
};
```




