### PR TITLE
Fix posix separator issue on Windows

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,9 +1,9 @@
-import fs from "fs/promises";
-import path from "path";
-import log from "./log.js";
-import { start as startViteServer } from "./server.js";
-import { start as startWebSocketServer } from "./ws.js";
-import templates from "./templates/index.js";
+import fs from 'fs/promises';
+import path from 'path';
+import log from './log.js';
+import { start as startViteServer } from './server.js';
+import { start as startWebSocketServer } from './ws.js';
+import templates from './templates/index.js';
 
 import { fileURLToPath } from 'url';
 
@@ -12,167 +12,188 @@ const __dirname = path.dirname(__filename);
 const timestamp = Date.now();
 
 export const run = async (entry, options) => {
-    let wsServer;
+	let wsServer;
 
-    function exit() {
-        process.off('SIGTERM', exit);
+	function exit() {
+		process.off('SIGTERM', exit);
 
-        if (wsServer) {
-            wsServer.close();
-        }
-    }
+		if (wsServer) {
+			wsServer.close();
+		}
+	}
 
-    process.once('SIGTERM', exit);
+	process.once('SIGTERM', exit);
 
-    try {
-        const entries = await createEntries(entry, options);
+	try {
+		const entries = await createEntries(entry, options);
 
-        if (entries.length > 0) {
-            const filepaths = await generateFiles(entries, options);
+		if (entries.length > 0) {
+			const filepaths = await generateFiles(entries, options);
 
-            if (!options.build) {
-                wsServer = await startWebSocketServer({
-                    cwd: process.cwd(),
-                });
-            }
+			if (!options.build) {
+				wsServer = await startWebSocketServer({
+					cwd: process.cwd(),
+				});
+			}
 
-            await startViteServer({
-                options,
-                timestamp,
-                filepaths,
-                entries,
-                fragment: {
-                    server: wsServer,
-                }
-            });
-        }
-    } catch(error) {
-        console.log(error);
-    }
+			await startViteServer({
+				options,
+				timestamp,
+				filepaths,
+				entries,
+				fragment: {
+					server: wsServer,
+				},
+			});
+		}
+	} catch (error) {
+		console.log(error);
+	}
 };
 
 async function createEntries(entry, options) {
-    if (entry === undefined) {
-        log.error(`Missing argument.`)
-        console.log(" Use --new flag to let fragment create the file.");
-        return;
-    }
-    
-    const entries = [];
-    let shouldCreateFile = options.new;
+	if (entry === undefined) {
+		log.error(`Missing argument.`);
+		console.log(' Use --new flag to let fragment create the file.');
+		return;
+	}
 
-    async function createEntryFile(entryPath) {
-        if (path.extname(entryPath) !== ".js") {
-            throw new Error(`File extension needs to be .js`);
-        }
+	const entries = [];
+	let shouldCreateFile = options.new;
 
-        const createFromTemplate = typeof options.template === "string";
-        const templateFiles = createFromTemplate ? templates[options.template] : templates.default;
+	async function createEntryFile(entryPath) {
+		if (path.extname(entryPath) !== '.js') {
+			throw new Error(`File extension needs to be .js`);
+		}
 
-        if (!templateFiles) {
-            throw new Error(`Error: Template ${options.template} doesn't exist.`);
-        }
+		const createFromTemplate = typeof options.template === 'string';
+		const templateFiles = createFromTemplate
+			? templates[options.template]
+			: templates.default;
 
-        const entryName = path.basename(entryPath, path.extname(entryPath));
+		if (!templateFiles) {
+			throw new Error(
+				`Error: Template ${options.template} doesn't exist.`,
+			);
+		}
 
-        for (let i = 0; i < templateFiles.length; i++) {
-            const filepath = path.join(__dirname, templateFiles[i]);
-            const ext = path.extname(filepath);
-            let fileContent = (await fs.readFile(filepath)).toString();
+		const entryName = path.basename(entryPath, path.extname(entryPath));
 
-            const destPath = i === 0 ? entryPath :
-                path.join(process.cwd(), `${entryName}${ext}`);
-            const destName = path.basename(destPath);
+		for (let i = 0; i < templateFiles.length; i++) {
+			const filepath = path.join(__dirname, templateFiles[i]);
+			const ext = path.extname(filepath);
+			let fileContent = (await fs.readFile(filepath)).toString();
 
-            const filepaths = templateFiles
-                .filter((file, index) => index !== i)
-                .map((file) => path.basename(file));
+			const destPath =
+				i === 0
+					? entryPath
+					: path.join(process.cwd(), `${entryName}${ext}`);
+			const destName = path.basename(destPath);
 
-            for (let i = 0; i < filepaths.length; i++) {
-                fileContent = fileContent.replace(new RegExp(filepaths[i], 'g'), `${entryName}${path.extname(filepaths[i])}`);
-            }
+			const filepaths = templateFiles
+				.filter((file, index) => index !== i)
+				.map((file) => path.basename(file));
 
-            try {
-                const stats = await fs.lstat(destPath);
+			for (let i = 0; i < filepaths.length; i++) {
+				fileContent = fileContent.replace(
+					new RegExp(filepaths[i], 'g'),
+					`${entryName}${path.extname(filepaths[i])}`,
+				);
+			}
 
-                if (stats.isFile()) {
-                    log.warning(`Ignored argument: --new. File already exists.`);
-                }
-            } catch(error) {
-                if (error.code === "ENOENT") {
-                    await fs.writeFile(destPath, Buffer.from(fileContent));
-                    console.log(`${log.prefix} Created ${path.relative(process.cwd(), destPath)} on disk.`);
-                } else {
-                    throw error;
-                }
-            }
-        }
+			try {
+				const stats = await fs.lstat(destPath);
 
-        shouldCreateFile = false;
-    }
+				if (stats.isFile()) {
+					log.warning(
+						`Ignored argument: --new. File already exists.`,
+					);
+				}
+			} catch (error) {
+				if (error.code === 'ENOENT') {
+					await fs.writeFile(destPath, Buffer.from(fileContent));
+					console.log(
+						`${log.prefix} Created ${path.relative(
+							process.cwd(),
+							destPath,
+						)} on disk.`,
+					);
+				} else {
+					throw error;
+				}
+			}
+		}
 
-    const entryPath = path.join(process.cwd(), entry);
+		shouldCreateFile = false;
+	}
 
-    try {
-        if (shouldCreateFile) {
-            await createEntryFile(entryPath);
-        }
+	const entryPath = path.join(process.cwd(), entry);
 
-        const stats = await fs.lstat(entryPath);
-        
-        if (stats.isFile()) {
-            entries.push(path.relative(process.cwd(), entryPath));
-        } else if (stats.isDirectory()) {
-            const files = await fs.readdir(entryPath);
-            const sketchFiles = files.filter((file) => path.extname(file) === ".js");
+	try {
+		if (shouldCreateFile) {
+			await createEntryFile(entryPath);
+		}
 
-            if (sketchFiles.length === 0) {
-                log.error(`Folder doesn't contain any sketch files.`);
-                console.log("Use --new flag to start working on a sketch.");
-                return;
-            }
+		const stats = await fs.lstat(entryPath);
 
-            entries.push(...sketchFiles.map((sketchFile) => path.relative(process.cwd(), sketchFile)));
-        }
-    } catch(error) {
-        if (error.code === "ENOENT") {
-            log.error(`Error: ${entry} doesn't exist.`);
-        } else {
-            log.error(error.message);
-        }
-    }
+		if (stats.isFile()) {
+			entries.push(path.relative(process.cwd(), entryPath));
+		} else if (stats.isDirectory()) {
+			const files = await fs.readdir(entryPath);
+			const sketchFiles = files.filter(
+				(file) => path.extname(file) === '.js',
+			);
 
-    
+			if (sketchFiles.length === 0) {
+				log.error(`Folder doesn't contain any sketch files.`);
+				console.log('Use --new flag to start working on a sketch.');
+				return;
+			}
 
-    return entries;
+			entries.push(
+				...sketchFiles.map((sketchFile) =>
+					path.relative(process.cwd(), sketchFile),
+				),
+			);
+		}
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			log.error(`Error: ${entry} doesn't exist.`);
+		} else {
+			log.error(error.message);
+		}
+	}
+
+	return entries;
 }
 
 async function generateFiles(entries, options) {
-    log.warning(`Building files for:`);
-    entries.forEach(entry => console.log(`- ${entry}`));
+	log.warning(`Building files for:`);
+	entries.forEach((entry) => console.log(`- ${entry}`));
 
-    const dir = "/node_modules/.fragment";
-    const dirpath = path.join(process.cwd(), dir);
-    const filename = `sketches.js`;
+	const dir = '/node_modules/.fragment';
+	const dirpath = path.join(process.cwd(), dir);
+	const filename = `sketches.js`;
 
-    // create directory and don't throw error if it already exists
-    try {
+	// create directory and don't throw error if it already exists
+	try {
 		await fs.mkdir(dirpath, { recursive: true });
 	} catch (e) {
 		if (e.code !== 'EEXIST') {
-            throw e;
-        }
+			throw e;
+		}
 	}
 
-    // generate sketch index file
-    const code = `
+	// generate sketch index file
+	const code = `
 // This file is generated by Fragment. Do not edit it.
 
 export const sketches = {
-    ${entries.map((entry) => {
-        return `"${entry}": () => import("../../${entry}")`
-    }).join(',')
-    }
+    ${entries
+		.map((entry) => {
+			return `"${entry}": () => import("../../${entry}")`;
+		})
+		.join(',')}
 };
 
 export const onSketchReload = (fn) => {
@@ -190,9 +211,9 @@ if (import.meta.hot) {
 }
 `;
 
-    const filepath = path.join(dirpath, filename);
+	const filepath = path.join(dirpath, filename);
 
-    await fs.writeFile(filepath, code);
+	await fs.writeFile(filepath, code);
 
-    return [filepath];
+	return [filepath];
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -191,7 +191,12 @@ async function generateFiles(entries, options) {
 export const sketches = {
     ${entries
 		.map((entry) => {
-			return `"${entry}": () => import("../../${entry}")`;
+			const entryPath = entry.split(sep).join(posix.sep);
+			const relativeEntryPath = `../../${entry}`
+				.split(sep)
+				.join(posix.sep);
+
+			return `"${entryPath}": () => import("${relativeEntryPath}")`;
 		})
 		.join(',')}
 };


### PR DESCRIPTION
This PR fixes an issue preventing Fragment to even start on Windows.

The generated files in the cached folder `.fragment` was using a hard coded `/`, while the value used for the entry path could be using either `/` on Unix systems and `\` on Windows. 

This fixes the issue by replacing the separator by `posix.sep` before writing the file.

