### PR TITLE
Fix field displayName hot reload

### DIFF
--- a/src/client/app/ui/FieldSection.svelte
+++ b/src/client/app/ui/FieldSection.svelte
@@ -3,7 +3,7 @@
 	export let visible = true;
 	export let secondary = false;
 	export let interactive = false;
-	export let displayName = key;
+	export let displayName = undefined;
 	export let disabled = false;
 </script>
 
@@ -17,10 +17,10 @@
 		{#if displayName !== null}
 			{#if interactive}
 				<button class="field__label" {disabled} on:click
-					>{displayName}</button
+					>{displayName ?? key}</button
 				>
 			{:else}
-				<span class="field__label">{displayName}</span>
+				<span class="field__label">{displayName ?? key}</span>
 			{/if}
 		{/if}
 		<slot name="infos" />


### PR DESCRIPTION
This PR fixes the hot reloading of field `displayName`.

The issue happens when removing the displayName property from a props declaration, where displayName would then be `undefined` and the displayed value would not properly fallback to `key`.