### PR TITLE
Run multiple sketches in the same folder

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -172,8 +172,20 @@ async function generateFiles(entries, options) {
 	entries.forEach((entry) => console.log(`- ${entry}`));
 
 	const dir = '/node_modules/.fragment';
+
+	const getFilenameFromEntries = (entries) => {
+		if (entries.length === 1) {
+			const filename = path.parse(entries[0]).name;
+
+			return `${filename}.js`;
+		}
+
+		return `sketches.js`;
+	};
+
 	const dirpath = path.join(process.cwd(), dir);
-	const filename = `sketches.js`;
+
+	const filename = getFilenameFromEntries(entries);
 
 	// create directory and don't throw error if it already exists
 	try {

--- a/src/client/app/components/Init.svelte
+++ b/src/client/app/components/Init.svelte
@@ -2,6 +2,7 @@
 	import { assignSketchFiles } from '../triggers/shared.js';
 	import { loadAll, sketchesKeys } from '../stores/sketches.js';
 	import { onSketchReload } from '@fragment/sketches';
+	import { getFilename } from '../utils/file.utils.js';
 	import '../utils/glslErrors.js';
 
 	sketchesKeys.subscribe((keys) => {
@@ -13,4 +14,13 @@
 	onSketchReload(({ sketches }) => {
 		loadAll(sketches);
 	});
+
+	$: prefix =
+		$sketchesKeys.length === 1 ? `${getFilename($sketchesKeys[0])} | ` : '';
+
+	$: title = `${prefix}fragment`;
 </script>
+
+<svelte:head>
+	<title>{title}</title>
+</svelte:head>

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -60,6 +60,15 @@ export function downloadBlob(blob, { filename = 'untitled' } = {}) {
 	a.click();
 }
 
+/**
+ * Extract filename and extension from a string path
+ * @param {string} path
+ * @returns {string} filename
+ */
+export function getFilename(path) {
+	return path.split(/[\\/]/).pop();
+}
+
 export function getFileExtension(path) {
 	const match = path.match(/[^\\/]\.([^.\\/]+)$/);
 


### PR DESCRIPTION
This PR fixes a conflict between servers and sketches when running multiple `fragment` commands from the same folder at the same time.

**Details**

When running a sketch `fragment` writes a file on start used for hot-reloading at `node_modules/.fragment/sketches.js`. But if two sketches shares this filepath, the second command will override the previously written file by the first command with path data for the second sketch.
This issue would not be visible as long as the first sketch was open in the browser before running the second command and if the first browser window was never reloaded after that. Otherwise, the first server would load the second sketch after a hard reload, creating a mismatch between the sketch the server is supposed to render and what it is actually rendered.

This fixes this conflict by reusing the sketch filename to create the file needed for hot reloading. The file is now `node_modules/.fragment/[sketch-filename].js`, so two different sketches won't try to read from the same file when trying to hot-reload anymore.