### PR TITLE
Props: preserve changes made in browser when hot reloaded

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -96,10 +96,16 @@
 					disabled
 				/>
 			{/if}
-			{#each Object.keys(sketchProps) as key, i (key)}
+			{#each Object.keys(sketchProps) as key, index (key)}
 				{@const sketchProp = sketchProps[key]}
-				{@const { hidden, displayName, value, type, disabled } =
-					sketchProp}
+				{@const {
+					hidden,
+					displayName,
+					value,
+					type,
+					disabled,
+					__initialValue: initialValue,
+				} = sketchProp}
 				{@const isDisabled =
 					typeof disabled === 'function' ? disabled() : disabled}
 				{#if typeof hidden === 'function' ? !hidden() : !hidden}
@@ -108,7 +114,9 @@
 						{key}
 						{displayName}
 						{value}
+						{initialValue}
 						{type}
+						{index}
 						disabled={isDisabled}
 						bind:params={sketchProps[key].params}
 						on:click={() => {

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -18,9 +18,22 @@ sketches.subscribe((sketches) => {
 	});
 });
 
+export function resetProps(sketchKey) {
+	props.update((all) => {
+		const sketchProps = all[sketchKey];
+
+		Object.keys(sketchProps).forEach((propKey) => {
+			sketchProps[propKey].value = sketchProps[propKey].__initialValue;
+		});
+
+		return all;
+	});
+}
+
 export function reconcile(newProps = {}, prevProps = {}) {
 	Object.keys(newProps).forEach((propKey) => {
 		let newProp = newProps[propKey];
+		newProp.__initialValue = newProp.value;
 
 		if (!newProp.params) {
 			newProp.params = {};
@@ -33,6 +46,10 @@ export function reconcile(newProps = {}, prevProps = {}) {
 			let newProp = newProps[propKey];
 
 			if (newProp) {
+				if (newProp.__initialValue === prevProp.__initialValue) {
+					newProp.value = prevProp.value;
+				}
+
 				if (prevProp.params) {
 					// reconcile locked VectorInput from UI
 					if (prevProp.params.locked !== undefined) {

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -40,11 +40,13 @@
 
 	export let key = '';
 	export let value = null;
+	export let initialValue = value;
 	export let context = null;
 	export let params = {};
 	export let type = null;
 	export let disabled = false;
 	export let displayName = undefined;
+	export let index = null;
 
 	let offsetWidth;
 	let showTriggers = false;
@@ -154,7 +156,9 @@
 	class:xxsmall
 	class:xsmall
 	class:small
+	class:changed={!disabled && value !== initialValue}
 	bind:offsetWidth
+	style="--index: {index};"
 >
 	<FieldSection
 		{key}
@@ -306,6 +310,30 @@
 
 		padding: 3px 6px 3px 12px;
 		border-bottom: 1px solid var(--color-spacing);
+	}
+
+	.field.changed:before {
+		content: '';
+
+		position: absolute;
+		top: 0px;
+		left: 0px;
+		bottom: 0px;
+		z-index: 1;
+
+		width: 4px;
+		/* height: 4px; */
+		/* border-radius: 2px; */
+
+		--stripes-offset: calc(var(--index) * 1.9px);
+
+		background: repeating-linear-gradient(
+			45deg,
+			var(--color-active) calc(0px + var(--stripes-offset)),
+			var(--color-active) calc(2px + var(--stripes-offset)),
+			transparent calc(2px + var(--stripes-offset)),
+			transparent calc(4px + var(--stripes-offset))
+		);
 	}
 
 	:global(.field__input .field) {

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -29,6 +29,7 @@
 	import { client } from '../client';
 	import { recordCanvas, screenshotCanvas } from '../utils/canvas.utils.js';
 	import ErrorOverlay from './ErrorOverlay.svelte';
+	import { resetProps } from '../stores/props';
 
 	export let key;
 	export let id = 0;
@@ -610,6 +611,7 @@
 		const keyboardEvent = event.detail;
 		if (!keyboardEvent.metaKey && !keyboardEvent.ctrlKey) {
 			keyboardEvent.preventDefault();
+			resetProps(key);
 			console.log(`[fragment] ${key} reloaded.`);
 			createSketch(key);
 		}


### PR DESCRIPTION
**Issue**
All the props are reset to their default values on each hot reload of a sketch. 

**Summary**
This preserves the current values of props if they were changed from GUIs and adds an indicator in the UI if the value of a prop is not the same one as in the code. A change in the default value (from code) will override the current value in browser.

**Details**
This PR adds an `__initialValue` key to every prop so they can be compared and reconciled when a sketch is hot reloaded. If the `__initialValue` is the same between the old props and the new ones, then the new value is overwritten by the old one. 
This also adds a little indicator (similar to what can be seen in code editors when a line has changed) on the left of a Field if the current value is not the same as the one declared in code. This makes it easy to spot any changes made in the UI and not yet reflected in code.
The key binding for refresh `R` that is in charge of reloading the sketch now also takes care of resetting props values to the default ones.