### PR TITLE
Move sketches subscription in Init to avoid deduping

### DIFF
--- a/src/client/app/components/Init.svelte
+++ b/src/client/app/components/Init.svelte
@@ -1,9 +1,28 @@
 <script>
 	import { assignSketchFiles } from '../triggers/shared.js';
-	import { loadAll, sketchesKeys } from '../stores/sketches.js';
+	import { loadAll, sketchesKeys, sketches } from '../stores/sketches.js';
 	import { onSketchReload } from '@fragment/sketches';
 	import { getFilename } from '../utils/file.utils.js';
 	import '../utils/glslErrors.js';
+	import { props, reconcile } from '../stores/props.js';
+
+	sketches.subscribe((sketches) => {
+		props.update((currentProps) => {
+			Object.keys(sketches).forEach((key) => {
+				const sketch = sketches[key];
+
+				if (sketch) {
+					// sketch can be undefined if failed to load
+					currentProps[key] = reconcile(
+						sketch.props,
+						currentProps[key],
+					);
+				}
+			});
+
+			return currentProps;
+		});
+	});
 
 	sketchesKeys.subscribe((keys) => {
 		if (keys.length > 0) {

--- a/src/client/app/stores/props.js
+++ b/src/client/app/stores/props.js
@@ -3,21 +3,6 @@ import { getStore } from './utils';
 
 export const props = getStore('props', {});
 
-sketches.subscribe((sketches) => {
-	props.update((currentProps) => {
-		Object.keys(sketches).forEach((key) => {
-			const sketch = sketches[key];
-
-			if (sketch) {
-				// sketch can be undefined if failed to load
-				currentProps[key] = reconcile(sketch.props, currentProps[key]);
-			}
-		});
-
-		return currentProps;
-	});
-});
-
 function resetProp(prop) {
 	function copyProperties(source, target) {
 		for (const key in source) {


### PR DESCRIPTION
This fixes errors on props reconciliation by ensuring reconciliation only happens once and not multiple times because of the deduped subscription to sketches stores. The subscription is moved to `Init.svelte` which ensures the subscription is only done once and not hot reloaded.