### PR TITLE
Support saving multiple files at once

### DIFF
--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -3,7 +3,7 @@ import { createConfig } from './createConfig.js';
 import { createFragmentFile } from './createFragmentFile.js';
 import { getEntries } from './getEntries.js';
 import { log, magenta, bold, cyan, red } from './log.js';
-import screenshot from './plugins/screenshot.js';
+import save from './plugins/save.js';
 import * as p from './prompts.js';
 import { prettifyTime } from './utils.js';
 import { start as startWebSocketServer } from './ws.js';
@@ -92,7 +92,7 @@ export async function run(entry, options = {}) {
 						cwd,
 					}),
 					hotShaderReplacement({ cwd, wss: fragmentServer }),
-					screenshot({ cwd, inlineExportDir: options.exportDir }),
+					save({ cwd, inlineExportDir: options.exportDir }),
 				],
 			}),
 		);

--- a/src/client/app/lib/canvas-recorder/utils.js
+++ b/src/client/app/lib/canvas-recorder/utils.js
@@ -1,8 +1,21 @@
+import { changeDpiDataUrl } from 'changedpi';
+
 const supportedEncodings = ['image/png', 'image/jpeg', 'image/webp'];
 
+/**
+ * Create a Data URL from a canvas
+ * @param {HTMLCanvasElement} canvas
+ * @param {object} [options]
+ * @param {string} [encoding="image/png"]
+ * @param {number} [encodingQuality=0.92]
+ * @param {number} [pixelsPerInch=72]
+ * @returns {object} result
+ * @returns {string} result.dataURL
+ * @returns {string} result.extension
+ */
 export function exportCanvas(
 	canvas,
-	{ encoding = 'image/png', encodingQuality = 0.92 } = {},
+	{ encoding = 'image/png', encodingQuality = 0.92, pixelsPerInch = 72 } = {},
 ) {
 	if (!supportedEncodings.includes(encoding))
 		throw new Error(`Invalid canvas encoding ${encoding}`);
@@ -14,9 +27,12 @@ export function exportCanvas(
 
 	let dataURL = canvas.toDataURL(encoding, encodingQuality);
 
+	if (encoding !== 'image/webp' && pixelsPerInch !== 72) {
+		dataURL = changeDpiDataUrl(dataURL, pixelsPerInch);
+	}
+
 	return {
 		extension,
-		type: encoding,
 		dataURL,
 	};
 }

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -5,7 +5,6 @@
 	import { sketches, sketchesKeys } from '../stores/sketches.js';
 	import { layout } from '../stores/layout.js';
 	import { rendering, SIZES, sync, monitors } from '../stores/rendering.js';
-	import { current as currentTime } from '../stores/time.js';
 	import { errors, displayError, clearError } from '../stores/errors.js';
 	import { exports, props } from '../stores/index.js';
 	import { findRenderer } from '../stores/renderers';
@@ -340,9 +339,6 @@
 				format: $exports.videoFormat,
 				imageEncoding: $exports.imageEncoding,
 				quality: $exports.videoQuality,
-				params: {
-					props: sketch.props,
-				},
 				onStart: () => {
 					beforeRecordCallbacks.forEach((callback) => {
 						callback(recordArgs);
@@ -532,9 +528,6 @@
 				pattern: sketch?.filenamePattern,
 				exportDir: sketch?.exportDir,
 				index: imageCount > 1 ? i : undefined,
-				params: {
-					props: sketch.props,
-				},
 			});
 			paused = false;
 			$capturing = false;

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -339,6 +339,9 @@
 				format: $exports.videoFormat,
 				imageEncoding: $exports.imageEncoding,
 				quality: $exports.videoQuality,
+				params: {
+					props: sketch?.props,
+				},
 				onStart: () => {
 					beforeRecordCallbacks.forEach((callback) => {
 						callback(recordArgs);
@@ -528,6 +531,9 @@
 				pattern: sketch?.filenamePattern,
 				exportDir: sketch?.exportDir,
 				index: imageCount > 1 ? i : undefined,
+				params: {
+					props: sketch?.props,
+				},
 			});
 			paused = false;
 			$capturing = false;

--- a/src/client/app/utils/canvas.utils.js
+++ b/src/client/app/utils/canvas.utils.js
@@ -49,7 +49,7 @@ export async function saveInBrowser(files) {
 }
 
 /**
- * Save files to disk by sending them to Fragment save plugin. Fallbacks to saveInBrowser if
+ * Save files to disk by sending them to Fragment save plugin. Fallback to saveInBrowser if fails
  * @param {File[]} files
  * @returns {Promise<string[]>}
  */

--- a/src/client/app/utils/canvas.utils.js
+++ b/src/client/app/utils/canvas.utils.js
@@ -107,7 +107,8 @@ export async function saveFiles(files = [], out = []) {
 
 			return out;
 		} else {
-			throw new Error(error);
+			console.error(`[fragment] Error while saving files on disk.`);
+			await saveInBrowser(files);
 		}
 	} else {
 		await saveInBrowser(files);

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -1,3 +1,37 @@
+/**
+ * @typedef {Object} File
+ * @property {string} filepath
+ * @property {string} exportDir
+ * @property {string} data
+ * @property {string} [encoding]
+ */
+
+/**
+ * Transform a Blob into a Data URL
+ * @param {Blob} blob
+ * @returns {Promise<string>}
+ */
+export async function createDataURLFromBlob(blob) {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+
+		reader.onerror = (err) => {
+			reject(err);
+		};
+
+		reader.onload = (e) => {
+			resolve(e.target.result);
+		};
+
+		reader.readAsDataURL(blob);
+	});
+}
+
+/**
+ * Transform a Data URL into a blob
+ * @param {string} dataURL
+ * @returns {Blob}
+ */
 export function createBlobFromDataURL(dataURL) {
 	return new Promise((resolve, reject) => {
 		const splitIndex = dataURL.indexOf(',');
@@ -96,11 +130,120 @@ export function getFileExtension(path) {
 /**
  *
  * @param {string} extension
- * @returns {string} mimeType
+ * @returns {string}
  */
 export function getMimeType(extension) {
 	if (extension === 'json') return 'application/json';
 	if (extension === 'txt') return 'text';
 	if (extension === 'png') return 'image/png';
 	if (extension === 'jpeg' || extension === 'jpg') return 'image/jpeg';
+}
+
+/**
+ *
+ * @param {File|File[]} files
+ */
+export async function saveInBrowser(files) {
+	/**
+	 * @param {File} file
+	 */
+	async function saveFile({ filename, data, blob }) {
+		if (!blob) {
+			blob = await createBlobFromDataURL(data);
+		}
+
+		await downloadBlob(blob, { filename });
+	}
+
+	if (Array.isArray(files)) {
+		return Promise.all(files.map((file) => saveFile(file)));
+	} else {
+		await saveFile(files);
+	}
+}
+
+/**
+ * Save files to disk by sending them to Fragment save plugin. Fallback to saveInBrowser if fails
+ * @param {File[]} files
+ * @returns {Promise<string[]>}
+ */
+export async function saveFiles(files = [], out = []) {
+	if (__DEV__) {
+		files.forEach((file) => {
+			if (!file.size) {
+				file.size = estimateFileSize(file.data);
+			}
+		});
+
+		const limitInMb = 100;
+		const body = {
+			files: [],
+		};
+
+		let size = 0;
+
+		for (let i = 0; i < files.length; i++) {
+			const file = files[i];
+			if (size < limitInMb) {
+				body.files.push(file);
+				size += file.size;
+			} else {
+				break;
+			}
+		}
+
+		const response = await fetch('/save', {
+			method: 'POST',
+			body: JSON.stringify(body),
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+		});
+		const { filepaths, error } = await response.json();
+
+		if (response.ok && filepaths?.length) {
+			out.push(...filepaths);
+
+			if (body.files.length < files.length) {
+				return saveFiles(files.slice(body.files.length), out);
+			}
+
+			if (out.length < 15) {
+				out.forEach((filepath) => {
+					console.log(`[fragment] Saved ${filepath}`);
+				});
+			} else {
+				console.log(`[fragment] Saved ${filepaths.length} files.`, {
+					filepaths: out,
+				});
+			}
+
+			return out;
+		} else {
+			console.error(`[fragment] Error while saving files on disk.`);
+			await saveInBrowser(files);
+		}
+	} else {
+		await saveInBrowser(files);
+	}
+}
+
+/**
+ * Save a blob on disk
+ * @param {Blob} blob
+ * @param {object} options
+ * @returns {Promise<string[]>}
+ */
+export async function saveBlob(blob, { filename, exportDir }) {
+	const data = await createDataURLFromBlob(blob);
+
+	return saveFiles([
+		{
+			filename,
+			data,
+			exportDir,
+			encoding: 'base64',
+		},
+	]);
 }

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -39,6 +39,12 @@ export function download(data, filename) {
 	downloadBlob(blob, { filename });
 }
 
+/**
+ * Download a blob from the browser
+ * @param {Blob} blob
+ * @param {object} [options]
+ * @param {string} [options.filename="untitled"]
+ */
 export function downloadBlob(blob, { filename = 'untitled' } = {}) {
 	let a = document.createElement('a');
 	a.style.visibility = 'hidden';
@@ -67,6 +73,16 @@ export function downloadBlob(blob, { filename = 'untitled' } = {}) {
  */
 export function getFilename(path) {
 	return path.split(/[\\/]/).pop();
+}
+
+/**
+ * Estimate file size in megabytes from a Data URL
+ * @param {string} data
+ * @returns {number}
+ */
+export function estimateFileSize(data) {
+	const base64Length = data.length - (data.indexOf(',') + 1);
+	return (base64Length * (3 / 4) - 2) / 1024 / 1024;
 }
 
 export function getFileExtension(path) {

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -214,7 +214,7 @@ export async function saveFiles(files = [], out = []) {
 					console.log(`[fragment] Saved ${filepath}`);
 				});
 			} else {
-				console.log(`[fragment] Saved ${filepaths.length} files.`, {
+				console.log(`[fragment] Saved ${out.length} files.`, {
 					filepaths: out,
 				});
 			}


### PR DESCRIPTION
This PR enables the ability to save multiple files in a single POST request to `/save`.

**Details**

- Send multiple files in a single POST request
- Rename `screenshot` plugin to `save`
- Split payload in multiple chunks if it's above the 100Mb limit 
- Move `changedpi` to `exportCanvas()` function
- Improve files and functions architecture
- Add JSDoc comments
