### PR TITLE
Add dispose lifecycle function

### DIFF
--- a/docs/api/sketch.md
+++ b/docs/api/sketch.md
@@ -14,6 +14,8 @@ await sketch.load();
 sketch.init();
 sketch.resize();
 sketch.update();
+// on sketch hot reload
+sketch.dispose();
 ```
 
 ## Exports

--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -182,6 +182,8 @@
 	async function createSketch(key) {
 		_created = false;
 
+		sketch?.dispose?.();
+
 		sketch = $sketches[key];
 
 		if (!key || !sketch) {


### PR DESCRIPTION
This PR adds a new sketch lifecycle function named `dispose()` that allows a sketch to run some code before getting reloaded, such as cleaning up effects, removing elements, destroying textures... and so on.

**Example**

```js
let element;

export let init = ({ canvas }) => {
	element = document.createElement('div');
	
	canvas.parentNode.appendChild(element);
}

export let dispose = () => {
    element.parentNode.removeChild(element);
}
```
