### PR TITLE
Fix onDestroyPreview in p5 renderers

### DIFF
--- a/src/client/app/renderers/P5GLRenderer.js
+++ b/src/client/app/renderers/P5GLRenderer.js
@@ -57,7 +57,7 @@ export let onResizePreview = ({ id, width, height, pixelRatio }) => {
 };
 
 export let onDestroyPreview = ({ id }) => {
-	const previewIndex = previews.find((p) => p.id === id);
+	const previewIndex = previews.findIndex((preview) => preview.id === id);
 	const preview = previews[previewIndex];
 
 	if (preview) {

--- a/src/client/app/renderers/P5Renderer.js
+++ b/src/client/app/renderers/P5Renderer.js
@@ -31,7 +31,7 @@ export let onResizePreview = ({ id, width, height, pixelRatio }) => {
 };
 
 export let onDestroyPreview = ({ id }) => {
-	const previewIndex = previews.find((p) => p.id === id);
+	const previewIndex = previews.findIndex((p) => p.id === id);
 	const preview = previews[previewIndex];
 
 	if (preview) {


### PR DESCRIPTION
This PR fixes the lookup for the existing previews in `onDestroyPreview` in both `P5Renderer` and `P5GLRenderer` where `preview` would be undefined, causing an issue where previous p5 contextes would stay in memory instead of being destroyed properly.