### PR TITLE
Replace arrow function in p5 webGL template

### DIFF
--- a/src/cli/templates/p5-webgl/index.js
+++ b/src/cli/templates/p5-webgl/index.js
@@ -17,7 +17,7 @@ let shader;
  * @param {number} params.height
  * @param {number} params.pixelRatio
  */
-export let setup = ({ p, width, height }) => {
+export function setup({ p, width, height }) {
 	shader = p.createShader(
 		/* glsl */ `
 attribute vec3 aPosition;
@@ -39,7 +39,7 @@ void main() {
 `,
 		fragmentShader,
 	);
-};
+}
 
 /**
  * @param {object} params


### PR DESCRIPTION
This PR replaces the arrow function used for the `setup` to fit with examples from p5.js website.