### PR TITLE
Prevent sketch update when loading

### DIFF
--- a/src/client/app/ui/SketchRenderer.svelte
+++ b/src/client/app/ui/SketchRenderer.svelte
@@ -460,7 +460,7 @@
 			elapsed += dt;
 
 			if (!$sync) {
-				if (elapsed >= (1 / framerate) * 1000) {
+				if (elapsed >= (1 / framerate) * 1000 && _created) {
 					elapsed = 0;
 					_renderSketch();
 				}


### PR DESCRIPTION
This PR fixes an issue that would happen when using the `load` lifecycle function of a sketch. If a sketch is already running and `load` exists and takes some time, the previous render loop would be called even after destroying correctly the preview, which could lead to various issues.

This PR ensures that the sketch exists before calling the `_renderSketch` function.