### PR TITLE
Prevent error when field value is null

### DIFF
--- a/src/client/app/utils/fields.utils.js
+++ b/src/client/app/utils/fields.utils.js
@@ -80,8 +80,8 @@ export function inferFieldType({ type, value, params, key }) {
 }
 
 export function hasChanged(initialValue, currentValue) {
-	const initialType = typeof initialValue;
-	const currentType = typeof currentValue;
+	const initialType = initialValue && typeof initialValue;
+	const currentType = currentValue && typeof currentValue;
 
 	if (initialType !== currentType) return true;
 


### PR DESCRIPTION
This PR fixes an issue when trying to keep track of value changes in `Field`.

If the initial or current value is `null`, the type would be `object`, leading to a TypeError when trying to diff changes in `hasChanged()`.

Checking initialValue and currentValue first fixes the error.