### PR TITLE
Fix build in current directory

### DIFF
--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -47,6 +47,10 @@ export async function build(entry, options) {
 			handleCancelledPrompt(outDir, prefix);
 		}
 
+		if (!outDir) {
+			outDir = '';
+		}
+
 		let outDirPath = path.join(cwd, outDir);
 
 		// create directory if it doesn't exist


### PR DESCRIPTION
**Summary**
This PR fixes an issue when trying to use the current directory as the outDir when prompted in the command line. 

**Details**
If the suggested directory name (infered from the sketch name) is removed, we get the prompt "Hit Enter to use current directory". However, `outDir` is then `undefined`, throwing an error while trying to create the path in the next line. 
This solves the issue by using an empty string if `outDir` is `undefined.