### PR TITLE
Fix print server urls in preview task

### DIFF
--- a/src/cli/preview.js
+++ b/src/cli/preview.js
@@ -37,17 +37,15 @@ export async function preview(dir, options = {}) {
 
 		const { resolvedUrls } = previewServer;
 
-		let urls = ``;
-
-		for (const url of resolvedUrls.local) {
-			urls += `${bold('Local')}:   ${bold(cyan(url))}\n`;
-		}
-
-		for (const url of resolvedUrls.network) {
-			urls += `${bold('Network')}: ${bold(cyan(url))}`;
-		}
-
-		p.note(urls);
+		let urls = [
+			...resolvedUrls.local.map(
+				(url) => `${bold('Local')}:   ${bold(cyan(url))}`,
+			),
+			...resolvedUrls.network.map(
+				(url) => `${bold('Network')}: ${bold(cyan(url))}`,
+			),
+		];
+		p.note(urls.join(`\n`));
 	} catch (error) {
 		log.error(`Error\n`, prefix);
 		console.error(error);


### PR DESCRIPTION
**Summary**

This PR fixes an issue with the display of URLs from the preview server in the terminal.

**Details**
In case of multiple networks URLs, the URLs would be in the same line and not separated by a space, displaying this kind of thing:

```bash
Network: http://localhost:4173/Network: http://192.168.0.1:4173
```

Beyond readability, this would break opening the link if the terminal supports it since the first one is interpreted as a link to `http://localhost:4173/Network` which is obviously wrong.