### PR TITLE
Extend vite config with fragment config

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -28,6 +28,7 @@ prog.command('run [entry]', '', { default: true })
 	.option('--outDir', 'Build output directory')
 	.option('--emptyOutDir', 'Empty outDir before static build')
 	.option('--base', 'Base public path when served in production', undefined)
+	.option('--config', 'Path to Fragment config file')
 	.option('--prompts', 'Enable interactive prompts', true)
 	.action((entry, options) => {
 		if (options.new) {
@@ -43,6 +44,7 @@ prog.command('run [entry]', '', { default: true })
 				emptyOutDir: options.emptyOutDir,
 				base: options.base,
 				prompts: options.prompts,
+				configFilepath: options.config,
 			});
 		}
 
@@ -50,6 +52,7 @@ prog.command('run [entry]', '', { default: true })
 			development: options.development,
 			exportDir: options.exportDir,
 			port: options.port,
+			configFilepath: options.config,
 		});
 	});
 

--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -95,13 +95,14 @@ export async function build(entry, options) {
 			);
 
 			const fragmentFilepath = await createFragmentFile(entries, cwd);
-			const config = createConfig(
+			const config = await createConfig(
 				entries,
 				fragmentFilepath,
 				{
 					dev: options.development,
 					build: true,
 				},
+				options.configFilepath,
 				cwd,
 			);
 

--- a/src/cli/createConfig.js
+++ b/src/cli/createConfig.js
@@ -1,10 +1,43 @@
 import path from 'node:path';
-import { defineConfig } from 'vite';
+import fs from 'node:fs';
+import { defineConfig, loadConfigFromFile, mergeConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 import checkDependencies from './plugins/check-dependencies.js';
 import { file } from './utils.js';
 import { log } from './log.js';
+
+export async function loadConfig({ cwd, filepath }) {
+	try {
+		let filename = `fragment.config.js`;
+		let configFile = filepath ? filepath : filename;
+		let configRoot = cwd;
+		let resolvedPath = path.resolve(cwd, configFile);
+
+		if (!fs.existsSync(resolvedPath)) {
+			if (filepath) {
+				log.error(`Config file not found: ${resolvedPath}`);
+			}
+			return {};
+		}
+
+		log.info(`Extending configuration from ${resolvedPath}`);
+
+		const { config } = await loadConfigFromFile(
+			{
+				command: 'build',
+				mode: 'dev',
+			},
+			configFile,
+			configRoot,
+		);
+
+		return config;
+	} catch (error) {
+		log.error(error);
+		return {};
+	}
+}
 
 /**
  * Create Vite config from entries
@@ -16,10 +49,11 @@ import { log } from './log.js';
  * @param {string} [cwd=process.cwd()]
  * @returns {import('vite').UserConfig}
  */
-export function createConfig(
+export async function createConfig(
 	entries,
 	fragmentFilepath,
 	{ dev = false, build = false } = {},
+	configFilepath,
 	cwd = process.cwd(),
 ) {
 	const entriesPaths = entries.map((entry) => path.join(cwd, entry));
@@ -28,55 +62,68 @@ export function createConfig(
 
 	log.info(`Creating Vite configuration...`);
 
-	return defineConfig({
-		configFile: false,
-		root,
-		logLevel: dev ? 'info' : 'silent',
-		resolve: {
-			alias: [
-				{ find: '@fragment/sketches', replacement: fragmentFilepath },
-				{ find: '@fragment', replacement: app },
-				{
-					find: 'three',
-					replacement: path.join(cwd, 'node_modules/three'),
-				},
-				{ find: 'p5', replacement: path.join(cwd, 'node_modules/p5') },
-				{
-					find: 'ogl',
-					replacement: path.join(cwd, 'node_modules/ogl'),
-				},
-			],
-		},
-		plugins: [
-			svelte({
-				configFile: false,
-				onwarn: (warning, handler) => {
-					if (dev) {
-						handler(warning);
-					} else {
-						return;
-					}
-				},
-			}),
-			checkDependencies({
-				cwd,
-				app,
-				entriesPaths,
-				build,
-			}),
-		],
-
-		define: {
-			__CWD__: `${JSON.stringify(cwd)}`,
-			__FRAGMENT_PORT__: undefined,
-			__START_TIME__: Date.now(),
-			__SEED__: Date.now(),
-			__BUILD__: build,
-			__DEV__: !build,
-		},
-		optimizeDeps: {
-			include: ['convert-length', 'webm-writer', 'changedpi'],
-			exclude: ['@fragment/sketches', ...entriesPaths],
-		},
+	const config = await loadConfig({
+		filepath: configFilepath,
+		cwd,
 	});
+
+	return mergeConfig(
+		defineConfig({
+			configFile: false,
+			root,
+			logLevel: dev ? 'info' : 'silent',
+			resolve: {
+				alias: [
+					{
+						find: '@fragment/sketches',
+						replacement: fragmentFilepath,
+					},
+					{ find: '@fragment', replacement: app },
+					{
+						find: 'three',
+						replacement: path.join(cwd, 'node_modules/three'),
+					},
+					{
+						find: 'p5',
+						replacement: path.join(cwd, 'node_modules/p5'),
+					},
+					{
+						find: 'ogl',
+						replacement: path.join(cwd, 'node_modules/ogl'),
+					},
+				],
+			},
+			plugins: [
+				svelte({
+					configFile: false,
+					onwarn: (warning, handler) => {
+						if (dev) {
+							handler(warning);
+						} else {
+							return;
+						}
+					},
+				}),
+				checkDependencies({
+					cwd,
+					app,
+					entriesPaths,
+					build,
+				}),
+			],
+			define: {
+				__CWD__: `${JSON.stringify(cwd)}`,
+				__FRAGMENT_PORT__: undefined,
+				__START_TIME__: Date.now(),
+				__SEED__: Date.now(),
+				__BUILD__: build,
+				__DEV__: !build,
+			},
+			optimizeDeps: {
+				include: ['convert-length', 'webm-writer', 'changedpi'],
+				exclude: ['@fragment/sketches', ...entriesPaths],
+			},
+		}),
+		config.vite ?? {},
+	);
 }

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -62,13 +62,14 @@ export async function run(entry, options = {}) {
 			cwd,
 		});
 
-		const config = createConfig(
+		const config = await createConfig(
 			entries,
 			fragmentFilepath,
 			{
 				dev: options.development,
 				build: false,
 			},
+			options.configFilepath,
 			cwd,
 		);
 


### PR DESCRIPTION
This PR adds the ability to create a `fragment.config.js` that can be used to extends vite configuration by specifying additional vite options. The final Vite config will be merged following the `mergeConfig` as explained in Vite.js docs.