### PR TITLE
Prevent initialization if sketch errored

### DIFF
--- a/src/client/app/state/rendering.svelte.js
+++ b/src/client/app/state/rendering.svelte.js
@@ -460,6 +460,8 @@ export class Render {
 		};
 
 		this.init = async () => {
+			if (this.errored) return;
+
 			clearError(this.sketch.key);
 			this.mountParams = this.renderer?.onMountPreview?.(this.params);
 			if (this.mountParams && this.mountParams.canvas !== this.canvas) {


### PR DESCRIPTION
If a sketch has errored between the unmount of the previous version and the new one, it can lead to infinite mounting.

This PR ensures we're not trying to mount a Sketch that has already errored.