### PR TITLE
Handle native event in Field onchange callback

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -148,6 +148,9 @@
 							// value(event, sketch.params);
 						}}
 						onchange={(v) => {
+							if (v.currentTarget && v.type === 'change') {
+								v = v.currentTarget.value;
+							}
 							sketch.updateProp(key, v);
 						}}
 					/>

--- a/src/client/app/state/utils.svelte.js
+++ b/src/client/app/state/utils.svelte.js
@@ -50,7 +50,7 @@ export function deepAssign(target, source) {
 }
 
 export function deepEqual(target, source) {
-	if (isObject(target) && isObject(target)) {
+	if (isObject(target) && isObject(source)) {
 		let isEqual = true;
 		for (const key in source) {
 			if (isEqual) {


### PR DESCRIPTION
This check if the value is received by the `onchange` callback of a <Field> is a native `change` event or not before assigning it to the new prop value.