### PR TITLE
Fix field changed detection

### DIFF
--- a/src/client/app/state/utils.svelte.js
+++ b/src/client/app/state/utils.svelte.js
@@ -74,3 +74,16 @@ export function deepEqual(target, source) {
 
 	return target === source;
 }
+
+export function deepClone(value) {
+	if (isFunction(value)) {
+		return value;
+	}
+
+	if (isObject(value)) {
+		const clone = structuredClone(value);
+		return clone;
+	}
+
+	return value;
+}

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -9,7 +9,7 @@
 	import ButtonInput from './fields/ButtonInput.svelte';
 	import ImageInput from './fields/ImageInput.svelte';
 	import IntervalInput from './fields/IntervalInput.svelte';
-	import { fieldTypes, hasChanged } from '../utils/fields.utils.js';
+	import { fieldTypes } from '../utils/fields.utils.js';
 
 	const fields = {
 		[`${fieldTypes.SELECT}`]: Select,
@@ -37,6 +37,7 @@
 	import IconTriggers from '../components/IconTriggers.svelte';
 	import IconLocked from '../components/IconLocked.svelte';
 	import ImportInput from './fields/ImportInput.svelte';
+	import { deepEqual } from '../state/utils.svelte';
 
 	let {
 		key,
@@ -91,7 +92,7 @@
 	let fieldType = $derived(inferFieldType({ type, value, params, key }));
 	let fieldProps = $derived(composeFieldProps(params, disabled));
 	let onTrigger = $derived(frameDebounce(onTriggers[fieldType]));
-	let input = $derived(fields[fieldType]);
+	let Component = $derived(fields[fieldType]);
 	let triggerable = $derived(
 		params.triggerable !== false &&
 			((fieldType === fieldTypes.NUMBER &&
@@ -117,12 +118,17 @@
 			context,
 		};
 	}
+
+	function hasChanged(current, next) {
+		const changed = !deepEqual(current, next);
+		return changed;
+	}
 </script>
 
 <div
 	class="field"
 	class:disabled
-	class:changed={!disabled && hasChanged(initialValue, value)}
+	class:changed={!disabled && hasChanged(value, initialValue)}
 	style="--index: {index};"
 >
 	<FieldSection
@@ -153,13 +159,7 @@
 				{/if}
 			</div>
 		{/snippet}
-		<svelte:component
-			this={input}
-			{value}
-			{...fieldProps}
-			{onchange}
-			onclick={onTrigger}
-		/>
+		<Component {value} {...fieldProps} {onchange} onclick={onTrigger} />
 		{@render children?.()}
 	</FieldSection>
 	{#if triggerable}

--- a/src/client/app/utils/fields.utils.js
+++ b/src/client/app/utils/fields.utils.js
@@ -43,11 +43,40 @@ export function inferFieldType({ type, value, params, key }) {
 
 		const isArray = Array.isArray(value);
 		const isObject = !isArray && typeof value === 'object';
-		const values = isObject ? Object.values(value) : value;
+		const getKeys = (value) => {
+			if (isArray) {
+				return value.map((_, index) => index);
+			}
+
+			if (!isArray && !isObject) return [0];
+
+			if (value.isVector3) {
+				return ['x', 'y', 'z'];
+			}
+
+			if (value.isVector4 || value.isQuaternion) {
+				return ['x', 'y', 'z', 'w'];
+			}
+
+			if (isObject) {
+				return Object.keys(value);
+			}
+		};
+
+		const getValues = (value, keys) => {
+			if (!isObject && !isArray) {
+				value = [value];
+			}
+
+			return keys.map((key) => value[key]);
+		};
+
+		const keys = getKeys(value);
+		const values = getValues(value, keys);
 
 		if (
 			isArray &&
-			value.length === 2 &&
+			values.length === 2 &&
 			typeof params.min === 'number' &&
 			typeof params.max === 'number'
 		) {
@@ -78,55 +107,4 @@ export function inferFieldType({ type, value, params, key }) {
 	}
 
 	console.warn(`Field: cannot find field type for ${key}`);
-}
-
-export function hasChanged(initialValue, currentValue) {
-	const initialType = initialValue && typeof initialValue;
-	const currentType = currentValue && typeof currentValue;
-
-	if (initialType !== currentType) return true;
-
-	if (Array.isArray(currentValue)) {
-		if (initialValue.length !== currentValue.length) {
-			return true;
-		}
-
-		for (let i = 0; i < currentValue.length; i++) {
-			if (currentValue[i] !== initialValue[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	if (initialType === 'object') {
-		const keys1 = Object.keys(initialValue);
-		const keys2 = Object.keys(currentValue);
-
-		if (
-			keys1.length !== keys2.length ||
-			!keys1.every((key) => keys2.includes(key))
-		) {
-			return true;
-		}
-
-		for (const key of keys1) {
-			const value1 = initialValue[key];
-			const value2 = currentValue[key];
-
-			if (typeof value1 === 'object' && typeof value2 === 'object') {
-				// If both values are objects, recursively compare them
-				if (hasChanged(value1, value2)) {
-					return true;
-				}
-			} else if (value1 !== value2) {
-				// If values are not objects, directly compare them
-				return true;
-			}
-
-			return false;
-		}
-	}
-
-	return initialValue !== currentValue;
 }

--- a/src/client/app/utils/math.utils.js
+++ b/src/client/app/utils/math.utils.js
@@ -22,6 +22,12 @@ export function clamp(value, min, max) {
 	return Math.max(min, Math.min(value, max));
 }
 
+/**
+ *
+ * @param {number} value
+ * @param {number} step
+ * @returns {number}
+ */
 export function roundToStep(value, step) {
 	return Math.round(value * (1 / step)) / (1 / step);
 }


### PR DESCRIPTION
This PR changes the computation of `hasChanged` for fields by using `deepEqual` and replaces the deprecated `svelte:component` directive with dynamic component definition