### PR TITLE
Fix canvas flickering when using resizing window mode

### DIFF
--- a/src/client/app/state/rendering.svelte.js
+++ b/src/client/app/state/rendering.svelte.js
@@ -320,12 +320,27 @@ export class Render {
 		this.time = 0;
 		this.recording = false;
 
-		$effect(() => {
+		let resizeTimeout;
+
+		$effect.pre(() => {
 			const { width, height, pixelRatio } = rendering;
 
 			if (this.loaded) {
-				this.resize(width, height, pixelRatio);
-			} else {
+				if (resizeTimeout) clearTimeout(resizeTimeout);
+
+				resizeTimeout = setTimeout(() => {
+					clearTimeout(resizeTimeout);
+					resizeTimeout = null;
+
+					this.resize(width, height, pixelRatio);
+				}, 0);
+			}
+		});
+
+		$effect(() => {
+			const { width, height, pixelRatio } = rendering;
+
+			if (!this.loaded) {
 				this.width = width;
 				this.height = height;
 				this.pixelRatio = pixelRatio;


### PR DESCRIPTION
This PR fixes the flickering of the canvas when `resizing` is set to `window` by relying to a timeout of 0