### PR TITLE
Fix nested folders duplicity

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -7,6 +7,7 @@
 	import { layout } from '../state/layout.svelte';
 	import FieldGroup from '../ui/FieldGroup.svelte';
 	import { sketchesManager } from '../state/sketches.svelte';
+	import { parseFolder } from '../utils/fields.utils';
 
 	let {
 		id = layout.getID(),
@@ -52,16 +53,25 @@
 
 			if (!sketchPropGroup || group === sketchPropGroup) {
 				if (folder) {
+					const parsed = parseFolder(folder);
+					const current = parsed.find((m) => m.isCurrent);
+
 					const fieldgroup = sketch?.propsFolders.find(
-						(f) => f.id === folder,
+						(f) => f.id === current.id,
 					);
 
 					if (fieldgroup) {
-						const { depth, root } = fieldgroup;
+						const { depth, rootId } = fieldgroup;
+						const root =
+							rootId &&
+							sketch?.propsFolders.find((f) => f.id === rootId);
 
 						if (depth === 0 && !tree.includes(fieldgroup)) {
 							tree.push(fieldgroup);
-						} else if (root && !tree.includes(root)) {
+						} else if (
+							root &&
+							!tree.some((fieldgroup) => fieldgroup.id === rootId)
+						) {
 							tree.push(root);
 						}
 					} else {
@@ -164,19 +174,21 @@
 						sketchProps[item.key],
 					)}
 				{:else if item.type === 'fieldgroup'}
-					<FieldGroup
-						name={item.displayName}
-						collapsed={item.collapsed}
-						onchange={(collapsed) => {
-							sketch.updateFolder(item, collapsed);
-						}}
-					>
-						{#if item.children.length > 0}
-							{#each item.children as child, childIndex}
-								{@render sketchPropItem(childIndex, child)}
-							{/each}
-						{/if}
-					</FieldGroup>
+					{#if !item.hidden}
+						<FieldGroup
+							name={item.displayName}
+							collapsed={item.collapsed}
+							onchange={(collapsed) => {
+								sketch.updateFolder(item, collapsed);
+							}}
+						>
+							{#if item.children.length > 0}
+								{#each item.children as child, childIndex}
+									{@render sketchPropItem(childIndex, child)}
+								{/each}
+							{/if}
+						</FieldGroup>
+					{/if}
 				{/if}
 			{/snippet}
 			{#each sketchPropsTree as sketchPropsTreeItem, index}

--- a/src/client/app/state/Sketch.svelte.js
+++ b/src/client/app/state/Sketch.svelte.js
@@ -1,6 +1,8 @@
+import { parseFolder } from '../utils/fields.utils';
 import { rendering } from './rendering.svelte';
 import {
 	deepAssign,
+	deepClone,
 	deepEqual,
 	hydrate,
 	isFunction,
@@ -46,7 +48,10 @@ class Sketch {
 
 	reset() {
 		Object.keys(this.props).forEach((key) => {
-			this.updateProp(key, this.props[key].__initialValue);
+			this.updateProp(
+				key,
+				$state.snapshot(this.props[key].__initialValue),
+			);
 		});
 
 		this.propsFolders.forEach((fieldgroup) => {
@@ -89,12 +94,16 @@ class Sketch {
 						) {
 							deepAssign(newProp.value, prevProp.value);
 							deepAssign(instanceProp.value, prevProp.value);
-							newProp.__currentValue = newProp.value;
+							newProp.__currentValue = deepClone(
+								$state.snapshot(newProp.value),
+							);
 						} else if (
 							newProp.__initialValue === prevProp.__initialValue
 						) {
 							newProp.value = prevProp.value;
-							newProp.__currentValue = newProp.value;
+							newProp.__currentValue = deepClone(
+								$state.snapshot(newProp.value),
+							);
 							instanceProp.value = prevProp.value;
 						}
 
@@ -164,18 +173,6 @@ class Sketch {
 		propsFoldersCollection,
 		propsGroupsCollection,
 	) {
-		const duplicateInitialValue = (value) => {
-			if (isFunction(value)) {
-				return value;
-			}
-
-			if (isObject(value)) {
-				return structuredClone(value);
-			}
-
-			return value;
-		};
-
 		let {
 			value,
 			params = {},
@@ -203,7 +200,7 @@ class Sketch {
 				? instanceProp.hidden
 				: () => instanceProp.hidden;
 
-		let initialValue = duplicateInitialValue(value);
+		let initialValue = deepClone(value);
 
 		if (group && !propsGroupsCollection.includes(group)) {
 			propsGroupsCollection.push(group);
@@ -216,7 +213,7 @@ class Sketch {
 		let prop = {
 			value,
 			__initialValue: initialValue,
-			__currentValue: value,
+			__currentValue: deepClone(value),
 			__hidden,
 			type,
 			params: structuredClone(params),
@@ -237,12 +234,16 @@ class Sketch {
 
 		if (prop) {
 			prop.value = newValue;
-			prop.__currentValue = newValue;
+			prop.__currentValue = deepClone(newValue);
 		}
 
 		if (instanceProp) {
 			if (!deepEqual(instanceProp.value, newValue)) {
-				instanceProp.value = newValue;
+				if (isObject(instanceProp.value) && isObject(newValue)) {
+					deepAssign(instanceProp.value, newValue);
+				} else {
+					instanceProp.value = newValue;
+				}
 			}
 
 			instanceProp.onChange?.(instanceProp, {
@@ -264,21 +265,24 @@ class Sketch {
 		if (!folder) return undefined;
 
 		let propFolder;
-		let names = folder.split('.');
 
-		if (names.length > 0) {
-			let root;
-			let collapsedRegex = /^(.*?)(?:\[collapsed=(true|false)\])?$/;
+		const parsed = parseFolder(folder);
 
-			for (let i = 0; i < names.length; i++) {
-				let name = names[i];
-				let match = name.match(collapsedRegex);
-				let displayName = match[1];
-				let collapsed = match[2] ? match[2] === 'true' : false;
+		if (parsed.length > 0) {
+			for (let i = 0; i < parsed.length; i++) {
+				let match = parsed[i];
+				let {
+					depth,
+					id,
+					parentId,
+					rootId,
+					isCurrent,
+					name,
+					attributes = {},
+				} = match;
+				let { collapsed = false } = attributes;
+				let displayName = name;
 
-				let depth = i;
-				let id = [...names].slice(0, i + 1).join('.');
-				let parentId = [...names].slice(0, i).join('.');
 				let parent =
 					depth > 0
 						? collection.find((f) => f.id === parentId)
@@ -296,7 +300,8 @@ class Sketch {
 						children: [],
 						parent,
 						depth,
-						root,
+						rootId,
+						hidden: false,
 					};
 
 					if (parent) {
@@ -306,11 +311,7 @@ class Sketch {
 					collection.push(fieldgroup);
 				}
 
-				if (i === 0) {
-					root = fieldgroup;
-				}
-
-				if (i === names.length - 1) {
+				if (isCurrent) {
 					fieldgroup.children.push({
 						type: 'field',
 						key,
@@ -326,7 +327,7 @@ class Sketch {
 
 	updateFolder(folder, collapsed) {
 		this.propsFolders.forEach((f, index) => {
-			if (f === folder) {
+			if (f.id === folder.id) {
 				this.propsFolders[index].collapsed = collapsed;
 			}
 		});
@@ -366,6 +367,9 @@ class Sketch {
 					!deepEqual(instanceProp.value, prop.__currentValue)
 				) {
 					this.updateProp(key, instanceProp.value);
+					prop.__initialValue = deepClone(
+						$state.snapshot(prop.value),
+					);
 				}
 
 				// sync displayName
@@ -460,6 +464,29 @@ class Sketch {
 		Object.keys(this.props).forEach((key) => {
 			if (!(key in (this.instance.props ?? {}))) {
 				delete this.props[key];
+			}
+		});
+
+		const fieldgroups = [...this.propsFolders].sort(
+			(a, b) => b.depth - a.depth,
+		);
+
+		fieldgroups.forEach((fieldgroup) => {
+			const hasAllFieldsHidden = fieldgroup.children
+				.filter((child) => child.type === 'field')
+				.every((child) => this.props[child.key].__hidden());
+			const hasAllFieldgroupsHidden = fieldgroup.children
+				.filter((child) => child.type === 'fieldgroup')
+				.every((child) => child.hidden);
+
+			if (hasAllFieldsHidden && hasAllFieldgroupsHidden) {
+				if (!fieldgroup.hidden) {
+					fieldgroup.hidden = true;
+				}
+			} else {
+				if (fieldgroup.hidden) {
+					fieldgroup.hidden = false;
+				}
 			}
 		});
 	}

--- a/src/client/app/utils/fields.utils.js
+++ b/src/client/app/utils/fields.utils.js
@@ -108,3 +108,46 @@ export function inferFieldType({ type, value, params, key }) {
 
 	console.warn(`Field: cannot find field type for ${key}`);
 }
+
+/**
+ *
+ * @param {string} folder
+ */
+export function parseFolder(folder) {
+	const regex = /(?<name>\w+)(?:\[(?<attributes>[^\]]+)\])?/g;
+	const matches = [...folder.matchAll(regex)];
+
+	const results = matches.map((match) => {
+		return {
+			name: match.groups.name,
+			attributes: match.groups.attributes
+				? Object.fromEntries(
+						match.groups.attributes
+							.split(', ')
+							.map((attr) => attr.split('=')),
+					)
+				: {},
+		};
+	});
+
+	let names = results.map((match) => match.name);
+
+	let rootId;
+
+	results.forEach((match, index) => {
+		let id = [...names].slice(0, index + 1).join('.');
+		let parentId = [...names].slice(0, index).join('.');
+
+		if (index === 0) {
+			rootId = id;
+		}
+
+		match.id = id;
+		match.parentId = parentId;
+		match.depth = index;
+		match.isCurrent = index === results.length - 1;
+		match.rootId = rootId;
+	});
+
+	return results;
+}


### PR DESCRIPTION
This PR fixes an error happening with nested folders or folders with different states. The ID was parsed on the side of the creation of folders but not properly parsed on the Params side to create the tree. This would lead to unexpected behaviour as such as duplicated folders in params on each refresh.