### PR TITLE
fix: props disabled state

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -139,8 +139,6 @@
 					disabled,
 					__initialValue: initialValue,
 				} = prop}
-				{@const isDisabled =
-					typeof disabled === 'function' ? disabled() : disabled}
 				{#if !hidden}
 					<Field
 						context={sketch.key}
@@ -150,7 +148,7 @@
 						{initialValue}
 						{type}
 						{index}
-						disabled={isDisabled}
+						{disabled}
 						bind:params={sketchProps[key].params}
 						triggers={prop.triggers}
 						onclick={(event) => {

--- a/src/client/app/state/Sketch.svelte.js
+++ b/src/client/app/state/Sketch.svelte.js
@@ -199,6 +199,10 @@ class Sketch {
 			typeof instanceProp.hidden === 'function'
 				? instanceProp.hidden
 				: () => instanceProp.hidden;
+		let __disabled =
+			typeof instanceProp.disabled === 'function'
+				? instanceProp.disabled
+				: () => instanceProp.disabled;
 
 		let initialValue = deepClone(value);
 
@@ -215,6 +219,9 @@ class Sketch {
 			__initialValue: initialValue,
 			__currentValue: deepClone(value),
 			__hidden,
+			__disabled,
+			hidden: __hidden(),
+			disabled: __disabled(),
 			type,
 			params: structuredClone(params),
 			triggers,
@@ -256,6 +263,7 @@ class Sketch {
 
 		Object.keys(this.props).forEach((key) => {
 			this.props[key].hidden = this.props[key].__hidden();
+			this.props[key].disabled = this.props[key].__disabled();
 		});
 
 		this.version++;
@@ -438,6 +446,8 @@ class Sketch {
 
 				// sync hidden
 				prop.hidden = prop.__hidden();
+				// sync disabled state
+				prop.disabled = prop.__disabled();
 
 				// sync params
 				if (instanceProp.params) {

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -222,10 +222,6 @@
 		padding-bottom: 0px !important;
 	}
 
-	.field.disabled {
-		pointer-events: none;
-	}
-
 	.field__actions {
 		display: flex;
 		align-items: center;

--- a/src/client/app/ui/FieldSection.svelte
+++ b/src/client/app/ui/FieldSection.svelte
@@ -16,6 +16,7 @@
 	class="field__section"
 	class:visible
 	class:secondary
+	class:disabled
 	class:nameless={displayName === null}
 >
 	<div class="field__infos">
@@ -48,8 +49,10 @@
 		grid-template-columns: 1fr;
 	}
 
-	:global(body:not(.fragment-dragging)) .field__section:hover .field__label,
-	.field__section:focus-within .field__label {
+	:global(body:not(.fragment-dragging))
+		.field__section:not(.disabled):hover
+		.field__label,
+	.field__section:not(.disabled):focus-within .field__label {
 		opacity: 1;
 	}
 

--- a/src/client/app/ui/fields/ButtonInput.svelte
+++ b/src/client/app/ui/fields/ButtonInput.svelte
@@ -11,7 +11,7 @@
 	} = $props();
 </script>
 
-<div class="button-container" class:disabled>
+<div class="button-input" class:disabled>
 	<button
 		class="button"
 		{disabled}
@@ -26,7 +26,7 @@
 </div>
 
 <style>
-	.button-container {
+	.button-input {
 		display: flex;
 		width: 100%;
 	}
@@ -57,15 +57,15 @@
 		color: var(--color-text-input-disabled);
 	}
 
-	:global(body:not(.fragment-dragging)) .button:hover {
+	:global(body:not(.fragment-dragging)) .button:not(:disabled):hover {
 		color: var(--color-text);
 
 		box-shadow: inset 0 0 0 1px
 			var(--box-shadow-color-active, var(--color-active));
 	}
 
-	:global(body:not(.fragment-dragging)) .button:active,
-	:global(body:not(.fragment-dragging)) .button:focus-visible {
+	:global(body:not(.fragment-dragging)) .button:not(:disabled):active,
+	:global(body:not(.fragment-dragging)) .button:not(:disabled):focus-visible {
 		box-shadow: 0 0 0 2px
 			var(--box-shadow-color-active, var(--color-active));
 	}

--- a/src/client/app/ui/fields/ColorInput.svelte
+++ b/src/client/app/ui/fields/ColorInput.svelte
@@ -217,7 +217,9 @@
 		pointer-events: none;
 	}
 
-	:global(body:not(.fragment-dragging)) .mirror:hover {
+	:global(body:not(.fragment-dragging))
+		.color-input:not(.disabled)
+		.mirror:hover {
 		box-shadow: inset 0 0 0 1px var(--box-shadow-color, var(--color-active));
 	}
 
@@ -229,8 +231,12 @@
 		width: 100%;
 		height: 100%;
 		opacity: 0;
-		cursor: pointer;
+
 		background: transparent;
 		border: none;
+	}
+
+	.color-input:not(.disabled) .input {
+		cursor: pointer;
 	}
 </style>

--- a/src/client/app/ui/fields/IntervalInput.svelte
+++ b/src/client/app/ui/fields/IntervalInput.svelte
@@ -94,9 +94,10 @@
 	}
 
 	function handleValueChange(index, newValue) {
-		value[index] = newValue;
+		let newValues = [...value];
+		newValues[index] = newValue;
 
-		onchange(value);
+		onchange(newValues);
 	}
 
 	$effect(() => {
@@ -141,7 +142,7 @@
 				{max}
 				progress={false}
 				value={value[0]}
-				on:change={(event) => handleValueChange(0, event.detail)}
+				onchange={(event) => handleValueChange(0, event)}
 			/>
 			<NumberInput
 				{label}
@@ -154,7 +155,7 @@
 				{max}
 				progress={false}
 				value={value[1]}
-				on:change={(event) => handleValueChange(1, event.detail)}
+				onchange={(event) => handleValueChange(1, event)}
 			/>
 		</div>
 	</FieldInputRow>

--- a/src/client/app/ui/fields/ProgressInput.svelte
+++ b/src/client/app/ui/fields/ProgressInput.svelte
@@ -87,7 +87,7 @@
 	aria-valuemin={min}
 	aria-valuemax={max}
 	aria-valuenow={value}
-	tabindex="0"
+	tabindex={disabled ? -1 : 0}
 >
 	<div
 		class="fill"


### PR DESCRIPTION
This PR fixes the disabled state of a prop when it's set from the sketch file:

```js
export let props = {
   test: {
       value: 12,
      disabled: true
   }
}
```

The issue was the disabled property was not properly cloned from the instance props to the sketch props, therefore reading `.disabled` from a sketch prop was always undefined.