### PR TITLE
fix: IntervalInput clone error

### DIFF
--- a/src/client/app/ui/fields/IntervalInput.svelte
+++ b/src/client/app/ui/fields/IntervalInput.svelte
@@ -81,7 +81,7 @@
 			value[0] = newValues[0];
 			value[1] = newValues[1];
 
-			onchange(value);
+			onchange(newValues);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue when trying to `structuredClone` the value passed as an update from `IntervalInput`. This fixes the issue by modifying the reference but propagating a clone in the `onchange` callback.