### PR TITLE
fix: render stays paused after loop record completed

### DIFF
--- a/src/client/app/state/rendering.svelte.js
+++ b/src/client/app/state/rendering.svelte.js
@@ -605,7 +605,7 @@ export class Render {
 			return;
 		}
 
-		this.record = await exports.record(this.canvas, {
+		this.record = exports.record(this.canvas, {
 			filename: sketch.key,
 			pattern: sketch.filenamePattern,
 			exportDir: sketch.exportDir,
@@ -627,6 +627,8 @@ export class Render {
 			onComplete: (params) => {
 				sketch.afterRecord.forEach((fn) => fn(params));
 				this.record = null;
+				this.paused = false;
+				this.recording = false;
 			},
 		});
 	}


### PR DESCRIPTION
This PR fixes an issue when recording a sketch with `useDuration = true` in the Exports module. Once a recording was complete, the sketch would stay in paused state because `paused` was not set back to false.