### PR TITLE
fix: resize call after reset

### DIFF
--- a/src/client/app/state/rendering.svelte.js
+++ b/src/client/app/state/rendering.svelte.js
@@ -649,7 +649,8 @@ export class Render {
 			this.sketch.instance?.dispose?.();
 			this.sketch.reset();
 
-			this.init();
+			this.loading = false;
+			this.loaded = false;
 		} catch (error) {
 			console.error(error);
 			displayError(error, this.sketch.key);


### PR DESCRIPTION
This PR fixes an issue when trying to reset the sketch. When hitting "R" to reload the sketch, only `sketch.init()` was called instead of the full lifecycle. 
This reset the state of the render to trigger $effect in order to re-initialize the sketch properly and go through its entire lifecycle.