### PR TITLE
feat: load sketches with Vite virtual modules

### DIFF
--- a/src/cli/createConfig.js
+++ b/src/cli/createConfig.js
@@ -6,6 +6,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import checkDependencies from './plugins/check-dependencies.js';
 import { file } from './utils.js';
 import { log } from './log.js';
+import sketches from './plugins/sketches.js';
 
 export async function loadConfig({ cwd, filepath }) {
 	try {
@@ -110,6 +111,7 @@ export async function createConfig(
 					entriesPaths,
 					build,
 				}),
+				sketches({ cwd, entries }),
 			],
 			define: {
 				__CWD__: `${JSON.stringify(cwd)}`,

--- a/src/cli/plugins/sketches.js
+++ b/src/cli/plugins/sketches.js
@@ -1,0 +1,44 @@
+import path from 'node:path';
+
+export default function sketches({ cwd, entries }) {
+	const virtualModuleId = 'virtual:sketches';
+	const resolvedVirtualModuleId = '\0' + virtualModuleId;
+
+	return {
+		name: 'fragment-plugin-sketches',
+		resolveId(id) {
+			if (id === virtualModuleId) {
+				return resolvedVirtualModuleId;
+			}
+		},
+		load(id) {
+			if (id === resolvedVirtualModuleId) {
+				return `
+				export const sketches = {
+    ${entries
+		.map((entry) => {
+			const entryPath = path.join(cwd, entry);
+
+			return `"${entry}": () => import("${entryPath}")`;
+		})
+		.join(',')}
+};
+
+export const onSketchReload = (fn) => {
+    if (import.meta.hot) {
+        import.meta.hot.data.onSketchChange = fn;
+    }
+};
+
+if (import.meta.hot) {
+    import.meta.hot.accept((m) => {
+        if (typeof import.meta.hot.data.onSketchChange === "function") {
+            import.meta.hot.data.onSketchChange(m);
+        }
+    });
+}
+				`;
+			}
+		},
+	};
+}

--- a/src/client/app/components/Init.svelte
+++ b/src/client/app/components/Init.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { assignSketchFiles } from '../triggers/shared.js';
 	import { sketchesManager } from '../state/sketches.svelte.js';
-	import { onSketchReload } from '@fragment/sketches';
+	import { onSketchReload } from 'virtual:sketches';
 	import { getFilename } from '../utils/file.utils.js';
 	import '../utils/glslErrors.js';
 

--- a/src/client/app/state/sketches.svelte.js
+++ b/src/client/app/state/sketches.svelte.js
@@ -1,5 +1,7 @@
 import { displayError } from '../state/errors.svelte.js';
-import { sketches as all } from '@fragment/sketches';
+
+import { sketches as all } from 'virtual:sketches';
+
 import Sketch from './Sketch.svelte.js';
 import { rendering } from './rendering.svelte.js';
 import { removeHotListeners } from '../triggers/index.js';


### PR DESCRIPTION
This PR changes the loading of the sketches by relying on Vite virtual modules instead of writing a fragment file on the local disk. This also solves some caching issues happening on other files when a sketch loads external files. 