### PR TITLE
fix: load custom renderer

### DIFF
--- a/src/client/app/state/rendering.svelte.js
+++ b/src/client/app/state/rendering.svelte.js
@@ -150,7 +150,7 @@ class Rendering {
 	}
 
 	findRenderer({ renderingMode }) {
-		return this.renderers[renderingMode].instance;
+		return this.renderers[renderingMode]?.instance;
 	}
 
 	override(config) {

--- a/src/client/app/state/sketches.svelte.js
+++ b/src/client/app/state/sketches.svelte.js
@@ -15,7 +15,7 @@ class SketchesManager {
 
 			await rendering.preloadRenderer({
 				renderingMode: sketch.rendering,
-				renderer: sketch.renderer,
+				customRenderer: sketch.renderer,
 			});
 
 			return sketch;


### PR DESCRIPTION
This PR fixes two issues happening when a sketch doesn't have a renderer or tries to load a custom renderer. This prevents a reference error when trying to read the instance but `renderingMode` is undefined, and this renames an argument passed down to rendering for reading the module exported by the sketch file.