### PR TITLE
feat: set default public path in config

### DIFF
--- a/src/cli/createConfig.js
+++ b/src/cli/createConfig.js
@@ -59,6 +59,7 @@ export async function createConfig(
 ) {
 	const entriesPaths = entries.map((entry) => path.join(cwd, entry));
 	const root = file('../client');
+	const publicDir = path.join(cwd, 'public');
 	const app = path.join(root, 'app');
 
 	log.info(`Creating Vite configuration...`);
@@ -73,6 +74,7 @@ export async function createConfig(
 			configFile: false,
 			root,
 			logLevel: dev ? 'info' : 'silent',
+			publicDir,
 			resolve: {
 				alias: [
 					{

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" href="/favicon.ico" />
+		<link rel="icon" href="./public/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<link rel="stylesheet" href="/css/global.css" />
+		<link rel="stylesheet" href="./public/css/global.css" />
 		<title>fragment</title>
 	</head>
 	<body>
@@ -13,6 +13,6 @@
 			<span class="loading__step">▢ Loading dependencies...</span>
 		</div>
 		<div id="app"></div>
-		<script type="module" src="/main.js"></script>
+		<script type="module" src="./main.js"></script>
 	</body>
 </html>

--- a/src/client/public/css/global.css
+++ b/src/client/public/css/global.css
@@ -8,7 +8,7 @@
 		local('Jetbrains-Mono-Regular'),
 		local('Jetbrains Mono'),
 		local('Jetbrains-Mono'),
-		url('/fonts/JetBrainsMono-Regular.woff2') format('woff2');
+		url('../fonts/JetBrainsMono-Regular.woff2') format('woff2');
 }
 
 :root {


### PR DESCRIPTION
This PR replaces the default public path resolved by Vite by resolving it based on the current processing directory of the `fragment` command. 
In order to still resolve public local files in fragment, the absolute paths of fonts and styles have been replaced by relative paths. 