### PR TITLE
fix: triggers reactive bindings causing svelte warnings

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -150,7 +150,7 @@
 						{index}
 						{disabled}
 						bind:params={sketchProps[key].params}
-						triggers={prop.triggers}
+						bind:triggers={prop.triggers}
 						onclick={(event) => {
 							sketch.version++;
 							// value(event, sketch.params);

--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -52,7 +52,7 @@
 		onchange,
 		onclick = () => {},
 		children,
-		triggers = [],
+		triggers = $bindable([]),
 	} = $props();
 
 	let showTriggers = $state(false);
@@ -165,7 +165,7 @@
 	{#if triggerable}
 		<FieldSection {key} visible={showTriggers} secondary>
 			<FieldTriggers
-				{triggers}
+				bind:triggers
 				{onTrigger}
 				{context}
 				triggerable={fieldType === fieldTypes.BUTTON}

--- a/src/client/app/ui/FieldTrigger.svelte
+++ b/src/client/app/ui/FieldTrigger.svelte
@@ -51,7 +51,7 @@
 		onchange = () => {},
 		onTrigger = () => {},
 		onDelete = () => {},
-		params = { key: [] },
+		params = $bindable({ key: [] }),
 	} = $props();
 
 	let validInputs = $derived.by(() =>
@@ -202,11 +202,11 @@
 			/>
 		{/if}
 		{#if inputType === 'Keyboard'}
-			<TextInput value={key} label="key" oninput={onTextChange} />
+			<TextInput bind:value={key} label="key" oninput={onTextChange} />
 		{/if}
 		{#if inputType === 'MIDI'}
 			<TextInput
-				value={key}
+				bind:value={key}
 				label={['onNoteOn', 'onNoteOff'].includes(eventName)
 					? 'note'
 					: 'number'}

--- a/src/client/app/ui/FieldTriggers.svelte
+++ b/src/client/app/ui/FieldTriggers.svelte
@@ -31,17 +31,15 @@
 		{#each triggers as trigger, index}
 			<FieldTrigger
 				{index}
+				bind:triggers
 				inputType={trigger.inputType}
 				eventName={trigger.eventName}
-				params={trigger.params}
+				bind:params={trigger.params}
 				enabled={trigger.enabled}
 				{onTrigger}
 				{context}
 				{controllable}
 				{triggerable}
-				onchange={(index, trigger) => {
-					triggers[index] = trigger;
-				}}
 				onDelete={onTriggerDelete}
 			/>
 		{/each}


### PR DESCRIPTION
This PR fixes bindings happening in `FieldTriggers` thanks to Svelte warnings.