### PR TITLE
feature: lib/gl FBO class

### DIFF
--- a/src/client/app/lib/gl/FBO.js
+++ b/src/client/app/lib/gl/FBO.js
@@ -1,0 +1,96 @@
+import Geometry from './Geometry.js';
+import Texture from './Texture.js';
+import Program from './Program';
+
+class FBO {
+	constructor(
+		renderer,
+		{
+			name = '',
+			vertex,
+			fragment,
+			uniforms,
+			width = 512,
+			height = 512,
+			type,
+			wrapS,
+			wrapT,
+			generateMipmaps = false,
+			format,
+			internalFormat,
+			minFilter,
+			magFilter,
+		},
+	) {
+		this.gl = renderer.gl;
+		this.renderer = renderer;
+
+		this.width = width;
+		this.height = height;
+
+		this.geometry = new Geometry(this.gl, {
+			position: { data: [-1, -1, 3, -1, -1, 3] },
+		});
+
+		this.program = new Program(this.gl, {
+			vertex,
+			fragment,
+			uniforms,
+		});
+
+		this.texture = new Texture(this.gl, {
+			name,
+			width,
+			height,
+			type,
+			wrapS,
+			wrapT,
+			generateMipmaps,
+			format,
+			internalFormat,
+			minFilter,
+			magFilter,
+		});
+		this.texture.update();
+
+		this.framebuffer = this.gl.createFramebuffer();
+		this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.framebuffer);
+		this.gl.framebufferTexture2D(
+			this.gl.FRAMEBUFFER,
+			this.gl.COLOR_ATTACHMENT0,
+			this.gl.TEXTURE_2D,
+			this.texture.glTexture,
+			0,
+		);
+	}
+
+	resize(width, height) {
+		this.width = width;
+		this.height = height;
+		this.texture.resize(width, height);
+	}
+
+	render() {
+		const viewport = this.gl.getParameter(this.gl.VIEWPORT);
+
+		this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, this.framebuffer);
+		this.gl.viewport(0, 0, this.width, this.height);
+		this.gl.clearColor(0, 0, 0, 1);
+		this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+		this.renderer.render({
+			geometry: this.geometry,
+			program: this.program,
+		});
+
+		this.gl.bindFramebuffer(this.gl.FRAMEBUFFER, null);
+		this.gl.viewport(...viewport);
+	}
+
+	destroy() {
+		this.texture.destroy();
+		this.gl.deleteFramebuffer(this.framebuffer);
+		this.framebuffer = null;
+	}
+}
+
+export default FBO;

--- a/src/client/app/lib/gl/Texture.js
+++ b/src/client/app/lib/gl/Texture.js
@@ -10,6 +10,8 @@ class Texture {
 		{
 			image = null,
 			name = '',
+			width,
+			height,
 			target = gl.TEXTURE_2D,
 			type = gl.UNSIGNED_BYTE,
 			wrapS = gl.CLAMP_TO_EDGE,
@@ -22,13 +24,13 @@ class Texture {
 			// premultiplyAlpha = false,
 			// unpackAlignment = 4,
 			flipY = target === gl.TEXTURE_2D ? true : false,
-			// width = image ? image.width : null,
-			// height = image ? image.height : null
 		} = {},
 	) {
 		this.gl = gl;
 		this.image = image;
 		this.name = name;
+		this.width = width;
+		this.height = height;
 		this.target = target;
 		this.type = type;
 		this.wrapS = wrapS;
@@ -54,6 +56,13 @@ class Texture {
 
 		this.gl.bindTexture(this.target, this.glTexture);
 		this.gl.state.textureUnits[this.gl.state.activeTextureUnit] = this.id;
+	}
+
+	resize(width, height) {
+		this.width = width;
+		this.height = height;
+		this.needsUpdate = true;
+		this.update();
 	}
 
 	update(textureUnit = 0) {
@@ -121,12 +130,12 @@ class Texture {
 				this.target,
 				0,
 				this.gl.RGBA,
-				1,
-				1,
+				this.width,
+				this.height,
 				0,
 				this.gl.RGBA,
 				this.gl.UNSIGNED_BYTE,
-				emptyPixel,
+				null, // emptyPixel,
 			);
 		}
 	}

--- a/src/client/app/lib/gl/index.js
+++ b/src/client/app/lib/gl/index.js
@@ -2,8 +2,9 @@ import Geometry from './Geometry.js';
 import Texture from './Texture.js';
 import Program, { defaultFragment, defaultVertex } from './Program.js';
 import Renderer from './Renderer.js';
+import FBO from './FBO.js';
 
-export { Geometry, Texture, Program, Renderer };
+export { Geometry, Texture, Program, Renderer, FBO };
 
 export function fragment({
 	canvas = document.createElement('canvas'),
@@ -47,6 +48,7 @@ export function fragment({
 
 	const frag = {
 		gl: renderer.gl,
+		renderer,
 		program,
 
 		texture: (params = {}) => new Texture(gl, params),

--- a/src/types/gl.d.ts
+++ b/src/types/gl.d.ts
@@ -49,6 +49,7 @@ declare module '@fragment/lib/gl' {
 		needsUpdate: boolean;
 		glTexture: WebGLTexture | null;
 		bind(): void;
+		resize: (width: number, height: number) => void;
 		update(textureUnit?: number): void;
 		destroy(): void;
 	}
@@ -105,8 +106,42 @@ declare module '@fragment/lib/gl' {
 		destroy(): void;
 	}
 
+	class FBO {
+		constructor(
+			renderer: Renderer,
+			params?: {
+				name?: string;
+				vertex?: string;
+				fragment?: string;
+				uniforms?: Uniforms;
+				width?: number;
+				height?: number;
+				type?: number;
+				wrapS?: number;
+				wrapT?: number;
+				generateMipmaps?: boolean;
+				format?: number;
+				internalFormat?: number;
+				minFilter?: number;
+				magFilter?: number;
+			},
+		);
+		gl: Gl;
+		renderer: Renderer;
+		geometry: Geometry;
+		program: Program;
+		texture: Texture;
+		framebuffer: WebGLFramebuffer | null;
+		width: number;
+		height: number;
+		resize: (width: number, height: number) => void;
+		render: () => void;
+		destroy: () => void;
+	}
+
 	interface Frag {
 		gl: Gl;
+		renderer: Renderer;
 		program: Program;
 		texture: (params?: {}) => Texture;
 		shader: string;


### PR DESCRIPTION
### Summary

This PR adds a FBO class to the Fragment GL library.

### Result

**Feature**
This class allows users to render any shader in a framebuffer object and use the rendered texture in the sketch final render. This gives control over textures parameters and resolutions while preventing complex noise calculations in the main shader (at every frame).

The `frag` object used in 'fragment' rendering sketches now contains the lib `renderer` in order to allow users to create custom FBOs.

**Types**
FBO class TypeScript support.

**Example**
```js
// sketch.js

const fragmentShader =  /* glsl */ `
	precision highp float;

	uniform vec2 uResolution;
	uniform sampler2D uNoise;
	uniform vec2 uNoiseResolution;
	
	const float noiseStrength = 0.1;
	const vec3 color = vec3(1.0, 0.5, 0.3);
	
	void main() {
		float noise = texture2D(uNoise, gl_FragCoord.xy / uNoiseResolution.xy).r;
		gl_FragColor = vec4(color + noise * noiseStrength, 1.0);
	}
`;

const noiseShader = /* glsl */ `
	precision mediump float;

	uniform vec2 uResolution;

	float random(in vec2 v) {
		return fract(sin(dot(v.xy, vec2(12.9898, 78.233))) * 43758.5453);
	}

	void main() {
		vec2 uv = gl_FragCoord.xy / uResolution;
		float v = random(uv);
		gl_FragColor = vec4(vec3(v), 1.0);
	}
`;

const uniforms = {
	uResolution: { value: [0, 0], type: 'vec2' },
	uNoise: { value: null, type: 'sampler2D' },
	uNoiseResolution: { value: [128, 128], type: 'vec2' }
};

export const load = ({ frag }) => {
	const gl = frag.gl;

	const noise = new FBO(frag.renderer, {
		width: 128,
		height: 128,
		fragment: noiseShader,
		uniforms: {
			uResolution: { value: [128, 128], type: 'vec2' }
		},
		wrapS: gl.REPEAT,
		wrapT: gl.REPEAT,
	});
	noise.render();

	uniforms.uNoise.value = noise.texture;
};

export const init = ({ frag }) => {
	frag.uniforms = uniforms;
	frag.shader = fragmentShader;
};

export const resize = ({ width, height, pixelRatio }) => {
	uniforms.uResolution.value[0] = width * pixelRatio;
	uniforms.uResolution.value[1] = height * pixelRatio;
};

export const update = ({ frag }) => {
	frag.render();
};

export const rendering = 'fragment';
```

Example main shader output:
![noise](https://github.com/user-attachments/assets/06c12359-96b2-4f4c-af1e-a120c4c472fc)
