### PR TITLE
fix: prevent build layout re-render if not persistent

### DIFF
--- a/src/client/app/ui/LayoutComponent.svelte
+++ b/src/client/app/ui/LayoutComponent.svelte
@@ -106,7 +106,7 @@
 >
 	{#if isRoot && layout.previewing}
 		<Preview />
-	{:else if childComponents.length > 0}
+	{:else if childComponents.length > 0 && layout.persistent}
 		{#each childComponents as child (child.id)}
 			{#if child.type === 'column' || child.type === 'row'}
 				<LayoutComponent


### PR DESCRIPTION
This fixes an issue where <Build /> would register the layout to the persistent state, unmounting <Build> to re-render of the whole layout based on the registered layout components. 
Since <Build> might contains <FloatingParams />  which is not a layout component, this would re-render WITHOUT <FloatingParams />, creating a non-consistent layout between a preview based on buildConfig and the actual build. 

Since we don't need to re-render the tree if the layout is non-persistent, we can add that condition to layout rendering, ensuring we keep <Build /> as it is.