### PR TITLE
feature: hooks parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Multiple rendering modes: [Canvas 2D](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API), [p5.js](https://github.com/processing/p5.js/), [three.js](https://github.com/mrdoob/three.js/), [WebGL fragment shaders](https://developer.mozilla.org/en-US/docs/Web/API/WebGLShader)
 - Built-in GUI from sketch files
 - Export `<canvas>` to images (.png, .webm, .jpg) or videos (.mp4, .webm, .gif) on the fly
-- Hot shader reloading & [glslify](https://github.com/glslify/glslify) support
+- Hot shader reloading
 - Interactive sketches using _triggers_
 - Static build for production deployment
 - TypeScript support

--- a/bin/index.js
+++ b/bin/index.js
@@ -21,39 +21,42 @@ prog.command('run [entry]', '', { default: true })
 	.describe('Run a dev environment for fragment')
 	.option('-n, --new', 'Create a new sketch', false)
 	.option('-t, --template', 'Specify template to create the file from', '2d')
-	.option('--typescript', 'Specify TypeScript support', false)
-	.option('-p, --port', 'Port to bind', 3000)
-	.option('-dev, --development', 'Enable development mode', false)
+	.option('--typescript', 'Specify TypeScript support')
 	.option('-b, --build', 'Build sketch for production', false)
-	.option('--exportDir', 'Directory used for exports')
+	.option('--base', 'Base public path when served in production')
 	.option('--outDir', 'Build output directory')
 	.option('--emptyOutDir', 'Empty outDir before static build')
-	.option('--base', 'Base public path when served in production', undefined)
+	.option('--exportDir', 'Directory used for exports')
+	.option('-dev, --development', 'Enable development mode', false)
+	.option('-p, --port', 'Port to bind')
+	.option('-o, --open', 'Open in browser')
+	.option('--prompts', 'Enable interactive prompts')
 	.option('--config', 'Path to Fragment config file')
-	.option('--prompts', 'Enable interactive prompts', true)
 	.action((entry, options) => {
 		if (options.new) {
 			return create(entry, {
 				templateName: options.template,
 				typescript: options.typescript,
+				configFilepath: options.config,
 			});
 		}
 
 		if (options.build) {
 			return build(entry, {
-				development: options.development,
+				base: options.base,
 				outDir: options.outDir,
 				emptyOutDir: options.emptyOutDir,
-				base: options.base,
+				development: options.development,
 				prompts: options.prompts,
 				configFilepath: options.config,
 			});
 		}
 
 		run(entry, {
-			development: options.development,
 			exportDir: options.exportDir,
+			development: options.development,
 			port: options.port,
+			open: options.open,
 			configFilepath: options.config,
 		});
 	});
@@ -61,31 +64,46 @@ prog.command('run [entry]', '', { default: true })
 prog.command('create [entry]')
 	.describe('Create a new sketch')
 	.option('-t, --template', 'Specify template to create the file from', '2d')
-	.option('--typescript', 'Specify TypeScript support', false)
+	.option('--typescript', 'Specify TypeScript support')
+	.option('--config', 'Path to Fragment config file')
 	.action((entry = '', options) => {
 		create(entry, {
 			templateName: options.template,
 			typescript: options.typescript,
+			configFilepath: options.config,
 		});
 	});
 
 prog.command('build [entry]')
 	.describe('Build a sketch')
-	.option('--outDir', 'Output folder', null)
+	.option('--base', 'Base public path')
+	.option('--outDir', 'Output folder')
 	.option('--emptyOutDir', 'Empty outDir before building for production')
-	.option('--base', 'Base public path', undefined)
 	.option('-dev, --development', 'Enable development mode', false)
-	.option('--prompts', 'Enable interactive prompts', true)
+	.option('--prompts', 'Enable interactive prompts')
 	.option('--config', 'Path to Fragment config file')
 	.action((entry, options) => {
-		build(entry, options);
+		build(entry, {
+			base: options.base,
+			outDir: options.outDir,
+			emptyOutDir: options.emptyOutDir,
+			development: options.development,
+			prompts: options.prompts,
+			configFilepath: options.config,
+		});
 	});
 
 prog.command('preview [directory]')
 	.describe('Preview a sketch')
-	.option('-o, --open', 'Open in browser', false)
+	.option('-p, --port', 'Port to bind')
+	.option('-o, --open', 'Open in browser')
+	.option('--config', 'Path to Fragment config file')
 	.action((dir, options) => {
-		preview(dir, options);
+		preview(dir, {
+			port: options.port,
+			open: options.open,
+			configFilepath: options.config,
+		});
 	});
 
 prog.parse(process.argv);

--- a/bin/index.js
+++ b/bin/index.js
@@ -94,7 +94,7 @@ prog.command('build [entry]')
 	});
 
 prog.command('preview [directory]')
-	.describe('Preview a sketch')
+	.describe('Start a local server to preview a sketch built locally with `fragment build`')
 	.option('-p, --port', 'Specify the server port')
 	.option('-o, --open', 'Flag to open the application in the browser when the server starts')
 	.option('--config', 'Path to Fragment config file')

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,19 +18,19 @@ const prog = sade('fragment');
 prog.version(`${version}`);
 
 prog.command('run [entry]', '', { default: true })
-	.describe('Run a dev environment for fragment')
-	.option('-n, --new', 'Create a new sketch', false)
-	.option('-t, --template', 'Specify template to create the file from', '2d')
-	.option('--typescript', 'Specify TypeScript support')
-	.option('-b, --build', 'Build sketch for production', false)
-	.option('--base', 'Base public path when served in production')
-	.option('--outDir', 'Build output directory')
-	.option('--emptyOutDir', 'Empty outDir before static build')
-	.option('--exportDir', 'Directory used for exports')
-	.option('-dev, --development', 'Enable development mode', false)
-	.option('-p, --port', 'Port to bind')
-	.option('-o, --open', 'Open in browser')
-	.option('--prompts', 'Enable interactive prompts')
+	.describe('Run an existing sketch')
+	.option('-n, --new', 'Redirect to create workflow', false)
+	.option('-t, --template', 'Pre-populate template choice in create prompts', '2d')
+	.option('--typescript', 'Pre-populate TypeScript support choice in create prompts')
+	.option('-b, --build', 'Redirect to build workflow', false)
+	.option('-dev, --development', 'Run Fragment in development mode', false)
+	.option('--outDir', 'Pre-populate outDir in build prompts')
+	.option('--emptyOutDir', 'Pre-populate emptyOutDir in build prompts')
+	.option('--base', 'Pre-populate base path in build prompts')
+	.option('--prompts', 'Toggle interactive prompts in build prompts')
+	.option('-p, --port', 'Specify the server port')
+	.option('-o, --open', 'Flag to open the application in the browser when the server starts')
+	.option('--exportDir', 'Override directory used for exports')
 	.option('--config', 'Path to Fragment config file')
 	.action((entry, options) => {
 		if (options.new) {
@@ -43,28 +43,28 @@ prog.command('run [entry]', '', { default: true })
 
 		if (options.build) {
 			return build(entry, {
-				base: options.base,
+				development: options.development,
 				outDir: options.outDir,
 				emptyOutDir: options.emptyOutDir,
-				development: options.development,
+				base: options.base,
 				prompts: options.prompts,
 				configFilepath: options.config,
 			});
 		}
 
 		run(entry, {
-			exportDir: options.exportDir,
 			development: options.development,
 			port: options.port,
 			open: options.open,
+			exportDir: options.exportDir,
 			configFilepath: options.config,
 		});
 	});
 
 prog.command('create [entry]')
 	.describe('Create a new sketch')
-	.option('-t, --template', 'Specify template to create the file from', '2d')
-	.option('--typescript', 'Specify TypeScript support')
+	.option('-t, --template', 'Pre-populate template choice', '2d')
+	.option('--typescript', 'Pre-populate TypeScript support choice')
 	.option('--config', 'Path to Fragment config file')
 	.action((entry = '', options) => {
 		create(entry, {
@@ -75,19 +75,19 @@ prog.command('create [entry]')
 	});
 
 prog.command('build [entry]')
-	.describe('Build a sketch')
-	.option('--base', 'Base public path')
-	.option('--outDir', 'Output folder')
-	.option('--emptyOutDir', 'Empty outDir before building for production')
+	.describe('Build a sketch into static files for production')
 	.option('-dev, --development', 'Enable development mode', false)
-	.option('--prompts', 'Enable interactive prompts')
+	.option('--outDir', 'Pre-populate out directory')
+	.option('--emptyOutDir', 'Pre-populate flag to empty outDir before static build')
+	.option('--base', 'Base public path when served in production')
+	.option('--prompts', 'Toggle interactive prompts')
 	.option('--config', 'Path to Fragment config file')
 	.action((entry, options) => {
 		build(entry, {
-			base: options.base,
+			development: options.development,
 			outDir: options.outDir,
 			emptyOutDir: options.emptyOutDir,
-			development: options.development,
+			base: options.base,
 			prompts: options.prompts,
 			configFilepath: options.config,
 		});
@@ -95,8 +95,8 @@ prog.command('build [entry]')
 
 prog.command('preview [directory]')
 	.describe('Preview a sketch')
-	.option('-p, --port', 'Port to bind')
-	.option('-o, --open', 'Open in browser')
+	.option('-p, --port', 'Specify the server port')
+	.option('-o, --open', 'Flag to open the application in the browser when the server starts')
 	.option('--config', 'Path to Fragment config file')
 	.action((dir, options) => {
 		preview(dir, {

--- a/docs/api/CLI.md
+++ b/docs/api/CLI.md
@@ -42,16 +42,19 @@ fragment run [filename]
 
 | Flag |  Description |
 |---|---|
-|`--port, -p`| Specify the server port. (default: `3000`)(`number`) |
-|`--exportDir`| Override directory used for exports (default: `undefined`)(`string`)|
 |`--new, -n`| Redirect to create workflow (default: `false`)(`boolean`) |
 |`--template, -t`| Pre-populate template choice in create prompts (default: `2d`)(`string`)|
+|`--typescript`| Pre-populate TypeScript support choice in create prompts (default: `false`)(`boolean`)|
 |`--build, -b`| Redirect to build workflow (default: `false`)(`boolean`) |
-|`--outDir`| Pre-populate outDir in build prompts  (default: `[/[sketch-name]`)(`string`)|
-|`--emptyOutDir`| Pre-populate emptyOutDir in build prompts (default: `false`)(`boolean`)|
-|`--base`| Pre-populate base path in build prompts (default: `undefined`)(`string`) |
-|`--development`| Run Fragment in development mode (default: `false`)(`boolean`) |
+|`--development, -dev`| Run Fragment in development mode (default: `false`)(`boolean`) |
+|`--outDir`| Pre-populate out directory in build prompts (default: `[/[sketch-name]`)(`string`)|
+|`--emptyOutDir`| Pre-populate flag to empty outDir before static build in build prompts (default: `true`)(`boolean`)|
+|`--base`| Pre-populate base public path in build prompts (default: `undefined`)(`string`) |
 |`--prompts`| Toggle interactive prompts in build prompts (default: `true`)(`boolean`) |
+|`--port, -p`| Specify the server port. (default: `3000`)(`number`) |
+|`--open, -o`| Flag to open the application in the browser when the server starts. (default: `false`)(`boolean`) |
+|`--exportDir`| Override directory used for exports (default: `undefined`)(`string`)|
+|`--config`| Path to Fragment config file (default: `undefined`)(`string`) |
 
 ## Build
 
@@ -69,10 +72,10 @@ fragment build [filename]
 
 | Flag | Description |
 |---|---|
-|`--outDir`| Pre-populate out directory (default: `[/[sketch-name]`)(`string`)|
-|`--emptyOutDir`| Empty outDir before static build (default: `false`)(`boolean`)|
-|`--base`| Base public path when served in production (default: `undefined`)(`string`)|
 |`--development`| Run Fragment in development mode (default: `false`)(`boolean`)|
+|`--outDir`| Pre-populate out directory (default: `[/[sketch-name]`)(`string`)|
+|`--emptyOutDir`| Pre-populate flag to empty outDir before static build (default: `false`)(`boolean`)|
+|`--base`| Pre-populate base public path (default: `undefined`)(`string`)|
 |`--prompts`| Enable interactive prompts (default: `true`)(`boolean`)|
 
 ### `fragment preview`

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -15,7 +15,65 @@ A different configuration file path can be provided using the `--config` flag on
 fragment sketch.js --config custom/path/to/config.js
 ```
 
-## Extending Vite
+## Config options
+
+### typescript
+
+- Type: `boolean`
+- Default: `false`
+
+Specify TypeScript support for new sketch creation.
+
+### base
+
+- Type: `string`
+- Default: `undefined`
+
+Base public path when served in production.
+
+### outDir
+
+- Type: `string`
+- Default: `undefined`
+
+Build output directory.
+
+### emptyOutDir
+
+- Type: `boolean`
+- Default: `true`
+
+Empty outDir before static build.
+
+### exportDir
+
+- Type: `string`
+- Default: `undefined`
+
+Directory used for exports.
+
+### port
+
+- Type: `number`
+- Default: `3000`
+
+Port to bind.
+
+### open
+
+- Type: `boolean`
+- Default: `false`
+
+Open in browser.
+
+### prompts
+
+- Type: `boolean`
+- Default: `true`
+
+Enable interactive prompts.
+
+### Extending Vite
 
 Vite's configuration can be extended by adding Vite options under the `vite` property in the config file.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -22,56 +22,56 @@ fragment sketch.js --config custom/path/to/config.js
 - Type: `boolean`
 - Default: `false`
 
-Specify TypeScript support for new sketch creation.
-
-### base
-
-- Type: `string`
-- Default: `undefined`
-
-Base public path when served in production.
+Pre-populate TypeScript support choice in create prompts.
 
 ### outDir
 
 - Type: `string`
 - Default: `undefined`
 
-Build output directory.
+Pre-populate out directory in build prompts.
 
 ### emptyOutDir
 
 - Type: `boolean`
 - Default: `true`
 
-Empty outDir before static build.
+Pre-populate flag to empty outDir before static build in build prompts.
 
-### exportDir
+### base
 
 - Type: `string`
 - Default: `undefined`
 
-Directory used for exports.
-
-### port
-
-- Type: `number`
-- Default: `3000`
-
-Port to bind.
-
-### open
-
-- Type: `boolean`
-- Default: `false`
-
-Open in browser.
+Pre-populate base public path in build prompts.
 
 ### prompts
 
 - Type: `boolean`
 - Default: `true`
 
-Enable interactive prompts.
+Toggle interactive prompts in build prompts.
+
+### port
+
+- Type: `number`
+- Default: `3000`
+
+Specify the server port.
+
+### open
+
+- Type: `boolean`
+- Default: `false`
+
+Flag to open the application in the browser when the server starts.
+
+### exportDir
+
+- Type: `string`
+- Default: `undefined`
+
+Override directory used for exports.
 
 ### Extending Vite
 

--- a/docs/guide/exporting-a-sketch.md
+++ b/docs/guide/exporting-a-sketch.md
@@ -75,8 +75,16 @@ This behavior can be customized via the [`filenamePattern`](../api/sketch.md#fil
 
 ## Changing the directory of exports
 
-By default, exports are saved to the working directory from which Fragment was launched. A custom directory can be defined by setting `exportDir` in your sketch file:
+By default, exports are saved to the working directory from which Fragment was launched. A custom directory can be defined by setting `exportDir` in your config file or in your sketch file:
 
 ```js
+// fragment.config.js
+export default {
+  exportDir: "/path/to/custom/directory"
+}
+```
+
+```js
+// sketch.js
 export let exportDir = "/path/to/custom/directory";
 ```

--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { readdir } from 'node:fs/promises';
 import { mergeConfig, build as viteBuild } from 'vite';
-import { createConfig } from './createConfig.js';
+import { loadConfig, createConfig } from './createConfig.js';
 import { getEntries } from './getEntries.js';
 import { log, magenta } from './log.js';
 import * as p from './prompts.js';
@@ -11,20 +11,19 @@ import hotShaderReplacement from './plugins/hot-shader-replacement.js';
 /**
  * Build a sketch for production
  * @param {string} entry
- * @param {object} options
+ * @param {object} [options={}]
  * @param {string} options.base
  * @param {string} options.outDir
  * @param {boolean} options.emptyOutDir
  * @param {boolean} options.development
+ * @param {boolean} options.prompts
  * @param {string} options.configFilepath
- * @param {boolean} [options.prompts=true]
+ * @returns {Promise<void>}
  */
-export async function build(entry, options) {
+export async function build(entry, { base, outDir, emptyOutDir, development, prompts, configFilepath } = {}) {
 	const cwd = process.cwd();
 	const command = 'build';
 	const prefix = log.prefix(command);
-
-	const { prompts = true } = options;
 
 	try {
 		const entries = await getEntries(entry, cwd, command, prefix);
@@ -33,8 +32,14 @@ export async function build(entry, options) {
 
 		log.message(`${magenta(entry)}\n`, prefix);
 
-		let outDir =
-			options.outDir ?? entries[0].split(path.extname(entries[0]))[0];
+		const fragmentConfig = await loadConfig({
+			cwd,
+			filepath: configFilepath,
+		});
+
+		base = base ?? fragmentConfig.base;
+		outDir = outDir ?? fragmentConfig.outDir ?? entries[0].split(path.extname(entries[0]))[0];
+		emptyOutDir = emptyOutDir ?? fragmentConfig.emptyOutDir;
 
 		if (prompts) {
 			outDir = await p.text({
@@ -58,8 +63,6 @@ export async function build(entry, options) {
 
 		const files = await readdir(outDirPath);
 
-		let emptyOutDir = options.emptyOutDir ?? true;
-
 		if (files.length > 0) {
 			log.warn(`${outDirPath} is not an empty folder.\n`);
 
@@ -74,8 +77,6 @@ export async function build(entry, options) {
 				handleCancelledPrompt(emptyOutDir, prefix);
 			}
 		}
-
-		let base = options.base;
 
 		if (prompts) {
 			base = await p.text({
@@ -97,10 +98,10 @@ export async function build(entry, options) {
 			const config = await createConfig(
 				entries,
 				{
-					dev: options.development,
+					dev: development,
 					build: true,
 				},
-				options.configFilepath,
+				fragmentConfig.vite,
 				cwd,
 			);
 
@@ -120,7 +121,7 @@ export async function build(entry, options) {
 					base,
 					build: {
 						outDir: outDirPath,
-						emptyOutDir,
+						emptyOutDir: emptyOutDir,
 					},
 					plugins: [hotShaderReplacement({ cwd })],
 				}),

--- a/src/cli/build.js
+++ b/src/cli/build.js
@@ -12,15 +12,15 @@ import hotShaderReplacement from './plugins/hot-shader-replacement.js';
  * Build a sketch for production
  * @param {string} entry
  * @param {object} [options={}]
- * @param {string} options.base
+ * @param {boolean} options.development
  * @param {string} options.outDir
  * @param {boolean} options.emptyOutDir
- * @param {boolean} options.development
+ * @param {string} options.base
  * @param {boolean} options.prompts
  * @param {string} options.configFilepath
  * @returns {Promise<void>}
  */
-export async function build(entry, { base, outDir, emptyOutDir, development, prompts, configFilepath } = {}) {
+export async function build(entry, { development, outDir, emptyOutDir, base, prompts, configFilepath } = {}) {
 	const cwd = process.cwd();
 	const command = 'build';
 	const prefix = log.prefix(command);

--- a/src/cli/create.js
+++ b/src/cli/create.js
@@ -2,6 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { createTsConfigFile } from './createFragmentFile.js';
+import { loadConfig } from './createConfig.js';
 import { log, magenta, bold, cyan, dim } from './log.js';
 import * as p from './prompts.js';
 import {
@@ -17,22 +18,30 @@ import {
 /**
  * Create a new sketch
  * @param {string} entry
- * @param {object} options
+ * @param {object} [options={}]
  * @param {string} options.templateName
  * @param {boolean} options.typescript
+ * @param {string} options.configFilepath
+ * @returns {Promise<void>}
  */
-export async function create(entry, { templateName, typescript } = {}) {
+export async function create(entry, { templateName, typescript, configFilepath } = {}) {
 	const cwd = process.cwd();
 	const prefix = log.prefix('create');
 
 	try {
 		log.message(`${magenta(entry)}\n`, prefix);
 
+		const fragmentConfig = await loadConfig({
+			cwd,
+			filepath: configFilepath,
+		});
+
+		typescript = typescript ?? fragmentConfig.typescript;
+
 		let dir, name;
 
 		if (entry) {
 			const { dir: entryDir, base: entryBase } = path.parse(entry);
-
 			dir = entryDir;
 			name = entryBase;
 		}

--- a/src/cli/createConfig.js
+++ b/src/cli/createConfig.js
@@ -9,6 +9,19 @@ import { __dirname, file } from './utils.js';
 import { log } from './log.js';
 import sketches from './plugins/sketches.js';
 
+/** @type import('../types/config.js').Config */
+export const DEFAULT_CONFIG = {
+	typescript: false,
+	base: undefined,
+	outDir: undefined,
+	emptyOutDir: true,
+	exportDir: undefined,
+	port: 3000,
+	open: false,
+	prompts: true,
+	vite: {},
+};
+
 /**
  *
  * @param {{ cwd: string, filepath: string | undefined }} params
@@ -43,7 +56,7 @@ export async function loadConfig({ cwd, filepath }) {
 
 		let configFile = path.relative(cwd, resolvedPath);
 
-		log.info(`Extending configuration from ${configFile}`);
+		log.info(`Loading configuration from ${configFile}`);
 
 		const config = (
 			await import(
@@ -51,7 +64,7 @@ export async function loadConfig({ cwd, filepath }) {
 			)
 		).default;
 
-		return config;
+		return Object.assign({}, DEFAULT_CONFIG, config);
 	} catch (error) {
 		log.error(error);
 		return {};
@@ -64,14 +77,14 @@ export async function loadConfig({ cwd, filepath }) {
  * @param {object} [options]
  * @param {boolean} [options.dev=false]
  * @param {boolean} [options.build=false]
- * @param {string} [configFilepath]
+ * @param {import('vite').UserConfig} [config]
  * @param {string} [cwd=process.cwd()]
  * @returns {import('vite').UserConfig}
  */
 export async function createConfig(
 	entries,
 	{ dev = false, build = false } = {},
-	configFilepath,
+	config = {},
 	cwd = process.cwd(),
 ) {
 	const entriesPaths = entries.map((entry) => path.join(cwd, entry));
@@ -80,11 +93,6 @@ export async function createConfig(
 	const app = path.join(root, 'app');
 
 	log.info(`Creating Vite configuration...`);
-
-	const config = await loadConfig({
-		cwd,
-		filepath: configFilepath,
-	});
 
 	return mergeConfig(
 		defineConfig({
@@ -132,6 +140,6 @@ export async function createConfig(
 				include: ['convert-length', 'changedpi'],
 			},
 		}),
-		config.vite ?? {},
+		config,
 	);
 }

--- a/src/cli/createConfig.js
+++ b/src/cli/createConfig.js
@@ -12,13 +12,13 @@ import sketches from './plugins/sketches.js';
 /** @type import('../types/config.js').Config */
 export const DEFAULT_CONFIG = {
 	typescript: false,
-	base: undefined,
 	outDir: undefined,
 	emptyOutDir: true,
+	base: undefined,
+	prompts: true,
 	exportDir: undefined,
 	port: 3000,
 	open: false,
-	prompts: true,
 	vite: {},
 };
 

--- a/src/cli/plugins/save.js
+++ b/src/cli/plugins/save.js
@@ -8,12 +8,14 @@ import { mkdirp } from '../utils.js';
  *
  * @param {object} [params]
  * @param {string} [cwd=process.cwd()] - Current working directory
- * @param {string} [inlineExportDir] - Directory path used for exports
+ * @param {string} [inlineExportDir] - Directory path used for exports from inline command
+ * @param {string} [configExportDir] - Directory path used for exports from config file
  * @returns {import('vite').Plugin}
  */
 export default function screenshot({
 	cwd = process.cwd(),
 	inlineExportDir,
+	configExportDir,
 } = {}) {
 	function resolveDirectory(directoryPath, dirname) {
 		return path.isAbsolute(directoryPath)
@@ -38,6 +40,12 @@ export default function screenshot({
 			}
 		} else if (exportDir) {
 			directory = resolveDirectory(exportDir, dirname);
+		} else if (configExportDir) {
+			if (!configExportDirPath) {
+				configExportDirPath = resolveDirectory(configExportDir);
+			}
+
+			directory = inlineExportDirPath;
 		} else {
 			directory = cwd;
 		}
@@ -46,6 +54,7 @@ export default function screenshot({
 	}
 
 	let inlineExportDirPath;
+	let configExportDirPath;
 
 	return {
 		name: 'save',

--- a/src/cli/plugins/save.js
+++ b/src/cli/plugins/save.js
@@ -28,24 +28,18 @@ export default function screenshot({
 
 		if (inlineExportDir) {
 			if (!inlineExportDirPath) {
-				inlineExportDirPath = resolveDirectory(inlineExportDir);
+				inlineExportDirPath = resolveDirectory(inlineExportDir, '');
 			}
 
 			directory = inlineExportDirPath;
-
-			if (exportDir) {
-				log.warning(
-					`'exportDir' configuration from sketch has been overridden by --exportDir.`,
-				);
-			}
 		} else if (exportDir) {
 			directory = resolveDirectory(exportDir, dirname);
 		} else if (configExportDir) {
 			if (!configExportDirPath) {
-				configExportDirPath = resolveDirectory(configExportDir);
+				configExportDirPath = resolveDirectory(configExportDir, '');
 			}
 
-			directory = inlineExportDirPath;
+			directory = configExportDirPath;
 		} else {
 			directory = cwd;
 		}

--- a/src/cli/preview.js
+++ b/src/cli/preview.js
@@ -1,16 +1,20 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { preview as vitePreview } from 'vite';
+import { loadConfig } from './createConfig.js';
 import { bold, cyan, log, magenta } from './log.js';
 import * as p from './prompts.js';
 
 /**
  * Preview a sketch
  * @param {string} dir
- * @param {object} [options]
- * @param {boolean} [options.open=false]
+ * @param {object} [options={}]
+ * @param {number} options.port
+ * @param {boolean} options.open
+ * @param {string} options.configFilepath
+ * @returns {Promise<void>}
  */
-export async function preview(dir, options = {}) {
+export async function preview(dir, { port, open, configFilepath } = {}) {
 	const cwd = process.cwd();
 	const prefix = log.prefix('preview');
 
@@ -25,13 +29,22 @@ export async function preview(dir, options = {}) {
 
 		log.message(`${magenta(outDir)}\n`, prefix);
 
+		const fragmentConfig = await loadConfig({
+			cwd,
+			filepath: configFilepath,
+		});
+
+		port = port ?? fragmentConfig.port;
+		open = open ?? fragmentConfig.open;
+
 		const previewServer = await vitePreview({
 			build: {
 				outDir,
 			},
 			preview: {
 				host: true,
-				open: options.open,
+				port,
+				open,
 			},
 		});
 

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -19,14 +19,14 @@ import hotShaderReplacement from './plugins/hot-shader-replacement.js';
  * Run a sketch
  * @param {string} entry
  * @param {object} [options={}]
- * @param {number} options.exportDir
  * @param {boolean} options.development
+ * @param {number} options.exportDir
  * @param {number} options.port
  * @param {boolean} options.open
  * @param {string} options.configFilepath
  * @returns {Promise<void>}
  */
-export async function run(entry, { exportDir, development, port, open, configFilepath } = {}) {
+export async function run(entry, { development, exportDir, port, open, configFilepath } = {}) {
 	let fragmentServer;
 	/** @type {import('node:fs').FSWatcher} */
 	let watcher;

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { createServer, mergeConfig } from 'vite';
-import { createConfig } from './createConfig.js';
+import { loadConfig, createConfig } from './createConfig.js';
 import {
 	createTsConfigFile,
 	FRAGMENT_DIRECTORY,
@@ -18,13 +18,15 @@ import hotShaderReplacement from './plugins/hot-shader-replacement.js';
 /**
  * Run a sketch
  * @param {string} entry
- * @param {object} options
+ * @param {object} [options={}]
+ * @param {number} options.exportDir
  * @param {boolean} options.development
  * @param {number} options.port
- * @param {number} options.exportDir
+ * @param {boolean} options.open
  * @param {string} options.configFilepath
+ * @returns {Promise<void>}
  */
-export async function run(entry, options = {}) {
+export async function run(entry, { exportDir, development, port, open, configFilepath } = {}) {
 	let fragmentServer;
 	/** @type {import('node:fs').FSWatcher} */
 	let watcher;
@@ -32,6 +34,8 @@ export async function run(entry, options = {}) {
 	const cwd = process.cwd();
 	const command = `run`;
 	const prefix = log.prefix(command);
+
+	const options = { exportDir, development, port, open, configFilepath };
 
 	const stop = () => {
 		fragmentServer?.close();
@@ -68,6 +72,15 @@ export async function run(entry, options = {}) {
 			);
 		}
 
+		const fragmentConfig = await loadConfig({
+			cwd,
+			filepath: configFilepath,
+		});
+
+		exportDir = exportDir ?? fragmentConfig.exportDir;
+		port = port ?? fragmentConfig.port;
+		open = open ?? fragmentConfig.open;
+
 		const hasTSFiles = entries.some((entry) => entry.endsWith('ts'));
 		const tsConfigDirpath = path.join(cwd, FRAGMENT_DIRECTORY);
 		const tsConfigFilepath = path.join(tsConfigDirpath, 'tsconfig.json');
@@ -82,10 +95,10 @@ export async function run(entry, options = {}) {
 		const config = await createConfig(
 			entries,
 			{
-				dev: options.development,
+				dev: development,
 				build: false,
 			},
-			options.configFilepath,
+			fragmentConfig.vite,
 			cwd,
 		);
 
@@ -94,8 +107,9 @@ export async function run(entry, options = {}) {
 		const server = await createServer(
 			mergeConfig(config, {
 				server: {
-					port: options.port,
 					host: true,
+					port,
+					open,
 					fs: {
 						strict: false,
 						allow: ['..'],
@@ -105,11 +119,9 @@ export async function run(entry, options = {}) {
 					__FRAGMENT_PORT__: fragmentServer.port,
 				},
 				plugins: [
-					hotSketchReload({
-						cwd,
-					}),
+					hotSketchReload({ cwd, }),
 					hotShaderReplacement({ cwd, wss: fragmentServer }),
-					save({ cwd, inlineExportDir: options.exportDir }),
+					save({ cwd, inlineExportDir: exportDir }),
 				],
 			}),
 		);
@@ -119,7 +131,7 @@ export async function run(entry, options = {}) {
 				['fragment.config.js', 'fragment.config.ts'].includes(
 					filename,
 				) ||
-				options.configFilepath?.includes(filename)
+				configFilepath?.includes(filename)
 			) {
 				log.warn(`${filename} has changed. Restarting...`);
 				console.log();

--- a/src/cli/run.js
+++ b/src/cli/run.js
@@ -77,7 +77,6 @@ export async function run(entry, { exportDir, development, port, open, configFil
 			filepath: configFilepath,
 		});
 
-		exportDir = exportDir ?? fragmentConfig.exportDir;
 		port = port ?? fragmentConfig.port;
 		open = open ?? fragmentConfig.open;
 
@@ -121,7 +120,7 @@ export async function run(entry, { exportDir, development, port, open, configFil
 				plugins: [
 					hotSketchReload({ cwd, }),
 					hotShaderReplacement({ cwd, wss: fragmentServer }),
-					save({ cwd, inlineExportDir: exportDir }),
+					save({ cwd, inlineExportDir: exportDir, configExportDir: fragmentConfig.exportDir }),
 				],
 			}),
 		);

--- a/src/client/app/hooks.js
+++ b/src/client/app/hooks.js
@@ -23,7 +23,7 @@ export const onAfterRecord = (listener, context = getContext()) => {
  * @param {object} options
  * @param {string} [options.filename]
  * @param {function} [options.pattern]
- * @param {exportDir} [options.pattern]
+ * @param {string} [options.exportDir]
  */
 export async function screenshot({ filename, pattern, exportDir } = {}) {
 	const context = getContext();

--- a/src/client/app/state/exports.svelte.js
+++ b/src/client/app/state/exports.svelte.js
@@ -1,3 +1,4 @@
+import { getFilenameParams, defaultFilenamePattern } from '../utils/file.utils';
 import { screenshotCanvas, recordCanvas } from '../utils/canvas.utils';
 import { hydrate, persist } from './utils.svelte';
 
@@ -96,7 +97,7 @@ class Exports {
 			quality = this.imageQuality,
 			pixelsPerInch = this.pixelsPerInch,
 			filename,
-			pattern,
+			pattern = defaultFilenamePattern,
 			exportDir,
 			params = {},
 			onStart = () => {},
@@ -105,11 +106,17 @@ class Exports {
 			onAfterCapture = () => {},
 		} = {},
 	) {
+		const patternParams = getFilenameParams();
+		const name = pattern({ filename, ...patternParams });
+
 		const captureParams = {
+			count,
 			encoding,
 			quality,
 			pixelsPerInch,
-			count,
+			name,
+			exportDir,
+			params,
 		};
 
 		onStart(captureParams);
@@ -118,14 +125,13 @@ class Exports {
 			onBeforeCapture(captureParams);
 
 			await screenshotCanvas(canvas, {
-				filename,
-				pattern,
-				exportDir,
 				index: count > 1 ? i : undefined,
-				params,
 				encoding,
 				quality,
 				pixelsPerInch,
+				name,
+				exportDir,
+				params,
 			});
 
 			onAfterCapture(captureParams);
@@ -137,14 +143,14 @@ class Exports {
 	record(
 		canvas,
 		{
-			framerate = this.framerate,
 			format = this.videoFormat,
-			imageEncoding = this.imageEncoding,
+			framerate = this.framerate,
+			duration,
 			quality = this.videoQuality,
 			codec = this.videoCodec,
-			duration,
+			imageEncoding = this.imageEncoding,
 			filename,
-			pattern,
+			pattern = defaultFilenamePattern,
 			exportDir,
 			params = {},
 			onStart = () => {},
@@ -154,30 +160,37 @@ class Exports {
 			onAfterRecord = () => {},
 		},
 	) {
+		const patternParams = getFilenameParams();
+		const name = pattern({ filename, ...patternParams });
+
 		const recordParams = {
-			framerate,
 			format,
-			imageEncoding,
-			quality,
+			framerate,
 			duration,
+			quality,
+			codec,
+			imageEncoding,
+			name,
+			exportDir,
+			params,
 		};
 
 		return recordCanvas(canvas, {
-			params,
+			format,
+			framerate,
+			duration: duration * this.loopCount,
+			quality,
+			codec,
+			imageEncoding,
 			filename,
 			exportDir,
 			pattern,
-			onTick,
-			framerate,
-			format,
-			codec,
-			imageEncoding,
-			quality,
-			duration: duration * this.loopCount,
+			params,
 			onStart: () => {
 				onStart(recordParams);
 				onBeforeRecord(recordParams);
 			},
+			onTick,
 			onComplete: () => {
 				this.recording = false;
 				onAfterRecord(recordParams);

--- a/src/client/app/utils/canvas.utils.js
+++ b/src/client/app/utils/canvas.utils.js
@@ -10,68 +10,29 @@ import { exportCanvas } from '../lib/canvas-recorder/utils';
 import { map } from './math.utils';
 import { createDataURLFromBlob, saveFiles } from './file.utils';
 
-function getFilenameParams() {
-	const now = new Date();
-
-	const year = now.toLocaleString('default', { year: 'numeric' });
-	const month = now
-		.toLocaleString('default', { month: 'numeric' })
-		.padStart(2, `0`);
-	const day = now
-		.toLocaleString('default', { day: 'numeric' })
-		.padStart(2, '0');
-	const hours = now
-		.toLocaleString('default', { hour: 'numeric', hour12: false })
-		.split(' ')[0];
-	const minutes = now
-		.toLocaleString('default', { minute: 'numeric' })
-		.padStart(2, `0`);
-	const seconds = now
-		.toLocaleString('default', { second: 'numeric' })
-		.padStart(2, `0`);
-
-	const timestamp = `${year}.${month}.${day}-${hours}.${minutes}.${seconds}`;
-
-	return {
-		year,
-		month,
-		day,
-		hours,
-		minutes,
-		seconds,
-		timestamp,
-	};
-}
-
-export const defaultFilenamePattern = ({ index, filename, timestamp }) => {
-	let name = `${filename}.${timestamp}`;
-
-	if (!isNaN(index)) {
-		name += `-${index}`;
-	}
-
-	return name;
-};
-
 /**
  *
  * @param {HTMLCanvasElement} canvas
- * @param {string} sketchKey
- * @param {Sketch} sketch
- * @param {number} [index]
+ * @param {object} options
+ * @param {number} [options.index]
+ * @param {string} [options.encoding='png']
+ * @param {number} [options.quality=100]
+ * @param {number} [options.pixelsPerInch=72]
+ * @param {string} [options.name='Screenshot']
+ * @param {string} [options.exportDir]
+ * @param {object} [options.params={}]
  * @param {Promise<string[]>}
  */
 export async function screenshotCanvas(
 	canvas,
 	{
-		filename = 'Screenshot',
 		index,
-		pattern = defaultFilenamePattern,
-		exportDir,
-		params = {},
 		encoding = 'png',
 		quality = 100,
 		pixelsPerInch = 72,
+		name = 'Screenshot',
+		exportDir,
+		params = {},
 	} = {},
 ) {
 	let { extension, dataURL } = exportCanvas(canvas, {
@@ -79,9 +40,6 @@ export async function screenshotCanvas(
 		encodingQuality: map(quality, 1, 100, 0, 1),
 		pixelsPerInch,
 	});
-
-	let patternParams = getFilenameParams();
-	let name = pattern({ filename, index, ...params, ...patternParams });
 
 	const files = [
 		{
@@ -121,27 +79,41 @@ function recordFrames(canvas, options) {
 	return recorder;
 }
 
+/**
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {object} options
+ * @param {string} [options.format='mp4']
+ * @param {number} [options.framerate=25]
+ * @param {number} [options.duration=Infinity]
+ * @param {number} [options.quality=100]
+ * @param {string} [options.codec]
+ * @param {string} [options.imageEncoding]
+ * @param {string} [options.name='Record']
+ * @param {string} [options.exportDir]
+ * @param {object} [options.params={}]
+ * @param {function} [options.onStart]
+ * @param {function} [options.onTick]
+ * @param {function} [options.onComplete]
+ * @param {Promise<string[]>}
+ */
 export function recordCanvas(
 	canvas,
 	{
-		filename = 'output',
 		format = 'mp4',
 		framerate = 25,
 		duration = Infinity,
 		quality = 100,
-		pattern = defaultFilenamePattern,
 		codec,
-		exportDir,
 		imageEncoding,
+		name = 'Record',
+		exportDir,
+		params = {},
 		onStart = () => {},
 		onTick = () => {},
 		onComplete = () => {},
-		params = {},
 	} = {},
 ) {
-	let patternParams = getFilenameParams();
-	let name = pattern({ filename, ...patternParams });
-
 	async function complete(result) {
 		const files = [];
 

--- a/src/client/app/utils/file.utils.js
+++ b/src/client/app/utils/file.utils.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} File
- * @property {string} filepath
+ * @property {string} filename
  * @property {string} exportDir
  * @property {string} data
  * @property {string} [encoding]
@@ -138,6 +138,49 @@ export function getMimeType(extension) {
 	if (extension === 'png') return 'image/png';
 	if (extension === 'jpeg' || extension === 'jpg') return 'image/jpeg';
 }
+
+export function getFilenameParams() {
+	const now = new Date();
+
+	const year = now.toLocaleString('default', { year: 'numeric' });
+	const month = now
+		.toLocaleString('default', { month: 'numeric' })
+		.padStart(2, `0`);
+	const day = now
+		.toLocaleString('default', { day: 'numeric' })
+		.padStart(2, '0');
+	const hours = now
+		.toLocaleString('default', { hour: 'numeric', hour12: false })
+		.split(' ')[0];
+	const minutes = now
+		.toLocaleString('default', { minute: 'numeric' })
+		.padStart(2, `0`);
+	const seconds = now
+		.toLocaleString('default', { second: 'numeric' })
+		.padStart(2, `0`);
+
+	const timestamp = `${year}.${month}.${day}-${hours}.${minutes}.${seconds}`;
+
+	return {
+		year,
+		month,
+		day,
+		hours,
+		minutes,
+		seconds,
+		timestamp,
+	};
+}
+
+export const defaultFilenamePattern = ({ index, filename, timestamp }) => {
+	let name = `${filename}.${timestamp}`;
+
+	if (!isNaN(index)) {
+		name += `-${index}`;
+	}
+
+	return name;
+};
 
 /**
  *

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * Type helper to make it easier to use fragment.config.js
+ * Declare config with full type inference support
  * @param {Config} config
  * @returns {Config}
  */

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,6 +1,13 @@
-import { UserConfig } from 'vite';
+import type { UserConfig } from 'vite';
 
 export interface Config {
+	typescript?: boolean;
+	base?: string;
+	outDir?: string;
+	emptyOutDir?: boolean;
+	exportDir?: string;
+	port?: number;
+	open?: boolean;
+	prompts?: boolean;
 	vite?: UserConfig;
-	[key: string]: any;
 }

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -2,12 +2,12 @@ import type { UserConfig } from 'vite';
 
 export interface Config {
 	typescript?: boolean;
-	base?: string;
 	outDir?: string;
 	emptyOutDir?: boolean;
+	base?: string;
+	prompts?: boolean;
 	exportDir?: string;
 	port?: number;
 	open?: boolean;
-	prompts?: boolean;
 	vite?: UserConfig;
 }

--- a/src/types/hooks.d.ts
+++ b/src/types/hooks.d.ts
@@ -1,14 +1,28 @@
 declare module '@fragment/hooks' {
-	type Listener = (params: {
+	type Parameters = {
+		name: string;
+		exportDir: string;
+		params: Record<string, any>;
+	};
+	type CaptureParameters = Parameters & {
 		encoding: string;
 		quality: number;
 		count: number;
 		index: number;
 		pixelsPerInch: number;
-	}) => Function | void;
+	};
+	type RecordParameters = Parameters & {
+		encoding: string;
+		quality: number;
+		framerate: number;
+	};
 
-	function onBeforeCapture(listener: Listener, context?: string): void;
-	function onAfterCapture(listener: Listener, context?: string): void;
-	function onBeforeRecord(listener: Listener, context?: string): void;
-	function onAfterRecord(listener: Listener, context?: string): void;
+	type Listener<P extends Parameters> = (parameters: P) => Function | void;
+	type CaptureListener = Listener<CaptureParameters>;
+	type RecordListener = Listener<RecordParameters>;
+
+	function onBeforeCapture(listener: CaptureListener, context?: string): void;
+	function onAfterCapture(listener: CaptureListener, context?: string): void;
+	function onBeforeRecord(listener: RecordListener, context?: string): void;
+	function onAfterRecord(listener: RecordListener, context?: string): void;
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,8 +1,7 @@
-import { Props } from './props';
+import type { Props } from './props';
 
 /**
  * Declare props with full type inference support
- *
  * @param {Props} props
  * @returns {Props}
  */


### PR DESCRIPTION
### Summary

This PR adds news parameters to Fragment's hooks in order to allow developers to generate and save custom files while matching Fragment sketches exporting logic.

### Example

This code would result in saving a _sketch.svg_ file after the capture of _sketch.png_, both in the same directory using the same filename pattern.

```js
import { saveFiles } from '@fragment/utils/file.utils';

onAfterCapture(({ name, exportDir }) => {
	const data = draw(); // custom code to generate data (for example: SVG code using [d3-path](https://d3js.org/d3-path))

	const files = [
		{
			filename: `${name}.svg`,
			exportDir,
			data: data
		}
	];

	saveFiles(files);
});
```