### PR TITLE
feature: add wrapper field type

### DIFF
--- a/src/client/app/ui/Field.svelte
+++ b/src/client/app/ui/Field.svelte
@@ -26,6 +26,7 @@
 		[`${fieldTypes.IMPORT}`]: ImportInput,
 		[`${fieldTypes.IMAGE}`]: ImageInput,
 		[`${fieldTypes.INTERVAL}`]: IntervalInput,
+		[`${fieldTypes.WRAPPER}`]: null,
 	};
 </script>
 

--- a/src/client/app/ui/ParamsOutput.svelte
+++ b/src/client/app/ui/ParamsOutput.svelte
@@ -102,7 +102,7 @@
 	/>
 {/if}
 {#if rendering.resizing === SIZES.PRESET}
-	<Field key="preset">
+	<Field key="preset" type="wrapper" value={`${rendering.preset}-${rendering.presetOrientation}`}>
 		<FieldInputRow --grid-template-columns="1fr 1fr">
 			<Select
 				value={rendering.preset}

--- a/src/client/app/utils/fields.utils.js
+++ b/src/client/app/utils/fields.utils.js
@@ -14,6 +14,7 @@ export const fieldTypes = {
 	IMPORT: 'import',
 	IMAGE: 'image',
 	INTERVAL: 'interval',
+	WRAPPER: 'wrapper',
 };
 
 /** @type string[] */


### PR DESCRIPTION
### Summary

This PR adds a field type `wrapper` to allow fields with no type or value.

```svelte
<Field key="preset" type="wrapper">
    <...>
</Field>
```
 
### Fixes

Fix `inferFieldType` warning: `Field: value undefined for preset`.