### PR TITLE
fix: set p5.js pixelDensity before canvas creation

### DIFF
--- a/src/client/app/renderers/P5GLRenderer.js
+++ b/src/client/app/renderers/P5GLRenderer.js
@@ -29,8 +29,16 @@ let previews = [];
  * @param {number} params.pixelRatio
  * @returns {MountParamsP5GLRenderer}
  */
-export let onMountPreview = ({ id, container, canvas, width, height }) => {
+export let onMountPreview = ({
+	id,
+	container,
+	canvas,
+	width,
+	height,
+	pixelRatio,
+}) => {
 	const p = new p5((sketch) => {
+		sketch.pixelDensity(pixelRatio);
 		sketch.setup = () => {
 			sketch.createCanvas(width, height, 'webgl', canvas);
 		};

--- a/src/client/app/renderers/P5Renderer.js
+++ b/src/client/app/renderers/P5Renderer.js
@@ -25,8 +25,16 @@ let previews = [];
  * @param {number} params.pixelRatio
  * @returns {MountParamsP5Renderer}
  */
-export let onMountPreview = ({ id, container, canvas, width, height }) => {
+export let onMountPreview = ({
+	id,
+	container,
+	canvas,
+	width,
+	height,
+	pixelRatio,
+}) => {
 	const p = new p5((sketch) => {
+		sketch.pixelDensity(pixelRatio);
 		sketch.setup = () => {
 			sketch.createCanvas(width, height, canvas);
 		};


### PR DESCRIPTION
This PR fixes a bug which was causing an infinite growth of canvas dimensions when rendering at a different `pixelRatio` than `window.devicePixelRatio` when using p5.js renderers