### PR TITLE
fix: prevent errors after deleting prop inside folder

### DIFF
--- a/src/client/app/modules/Params.svelte
+++ b/src/client/app/modules/Params.svelte
@@ -131,38 +131,40 @@
 		{/if}
 		{#if typeof sketchProps === 'object'}
 			{#snippet sketchField(index, key, prop)}
-				{@const {
-					hidden,
-					displayName,
-					value,
-					type,
-					disabled,
-					__initialValue: initialValue,
-				} = prop}
-				{#if !hidden}
-					<Field
-						context={sketch.key}
-						{key}
-						{displayName}
-						{value}
-						{initialValue}
-						{type}
-						{index}
-						{disabled}
-						bind:params={sketchProps[key].params}
-						bind:triggers={prop.triggers}
-						trackChanges
-						onclick={(event) => {
-							sketch.version++;
-							// value(event, sketch.params);
-						}}
-						onchange={(v) => {
-							if (v?.currentTarget && v?.type === 'change') {
-								v = v.currentTarget.value;
-							}
-							sketch.updateProp(key, v);
-						}}
-					/>
+				{#if prop}
+					{@const {
+						hidden,
+						displayName,
+						value,
+						type,
+						disabled,
+						__initialValue: initialValue,
+					} = prop}
+					{#if !hidden}
+						<Field
+							context={sketch.key}
+							{key}
+							{displayName}
+							{value}
+							{initialValue}
+							{type}
+							{index}
+							{disabled}
+							bind:params={sketchProps[key].params}
+							bind:triggers={prop.triggers}
+							trackChanges
+							onclick={(event) => {
+								sketch.version++;
+								// value(event, sketch.params);
+							}}
+							onchange={(v) => {
+								if (v?.currentTarget && v?.type === 'change') {
+									v = v.currentTarget.value;
+								}
+								sketch.updateProp(key, v);
+							}}
+						/>
+					{/if}
 				{/if}
 			{/snippet}
 			{#snippet sketchPropItem(index, item)}

--- a/src/client/app/state/Sketch.svelte.js
+++ b/src/client/app/state/Sketch.svelte.js
@@ -409,7 +409,13 @@ class Sketch {
 					collection.push(fieldgroup);
 				}
 
-				if (fieldgroup && isCurrent) {
+				if (
+					fieldgroup &&
+					isCurrent &&
+					!fieldgroup.children.some(
+						(c) => c.type === 'field' && c.key === key,
+					)
+				) {
 					fieldgroup.children.push({
 						type: 'field',
 						key,


### PR DESCRIPTION
This prevents errors when trying to dynamically delete existing props that already lives inside prop folders.

```js
export const props = {
	speed0: {
		value: 0.1,
		folder: 'speeds'
	},
	speed1: {
		value: 0.2,
		folder: 'speeds'
	},
    speedDelete: {
		value: () => {
			delete props["speed1"]
		}
	}
}
```